### PR TITLE
Fix README and configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ In addition, you might want to stop any other actively-running software on the t
 ### 1. Get the x86-64 ISA description:
 
 ```bash
-cd src/x86/isa_loader
+cd src/x86/isa_spec
 ./get_spec.py --extensions BASE SSE SSE2 CLFLUSHOPT CLFSH
 ```
 

--- a/src/tests/test-detection.yaml
+++ b/src/tests/test-detection.yaml
@@ -1,16 +1,16 @@
 instruction_categories:
-  - NOP
-  - BINARY
-  - BITBYTE
-  - COND_BR
-  - CMOV
-  - CONVERT
-  - DATAXFER
-  - FLAGOP
-  - SETCC
-  - LOGICAL
-  - POP
-  - PUSH
+  - BASE-NOP
+  - BASE-BINARY
+  - BASE-BITBYTE
+  - BASE-COND_BR
+  - BASE-CMOV
+  - BASE-CONVERT
+  - BASE-DATAXFER
+  - BASE-FLAGOP
+  - BASE-SETCC
+  - BASE-LOGICAL
+  - BASE-POP
+  - BASE-PUSH
 contract_observation_clause: ct
 contract_execution_clause:
   - seq

--- a/src/tests/test-nondetection.yaml
+++ b/src/tests/test-nondetection.yaml
@@ -1,16 +1,16 @@
 instruction_categories:
-  - NOP
-  - BINARY
-  - BITBYTE
-  - COND_BR
-  - CMOV
-  - CONVERT
-  - DATAXFER
-  - FLAGOP
-  - SETCC
-  - LOGICAL
-  - POP
-  - PUSH
+  - BASE-NOP
+  - BASE-BINARY
+  - BASE-BITBYTE
+  - BASE-COND_BR
+  - BASE-CMOV
+  - BASE-CONVERT
+  - BASE-DATAXFER
+  - BASE-FLAGOP
+  - BASE-SETCC
+  - BASE-LOGICAL
+  - BASE-POP
+  - BASE-PUSH
 contract_observation_clause: ct
 contract_execution_clause:
   - cond


### PR DESCRIPTION
- the README command `cd` into a directory which does not exist
- Configuration files in `src/tests` directory specify  instructions' category that does not match the categories' names. 