### PR TITLE
Exception handling

### DIFF
--- a/src/factory.py
+++ b/src/factory.py
@@ -46,8 +46,7 @@ X86_SIMPLE_EXECUTION_CLAUSES: Dict[str, Type[x86_model.X86UnicornModel]] = {
     "div-overflow": x86_model.X86UnicornDivOverflow,
     "meltdown": x86_model.X86Meltdown,
     "fault-skip": x86_model.X86FaultSkip,
-    "ooo-gp": x86_model.X86NonCanonicalOOO,
-    "noncanonical": x86_model.X86NonCanonicalOOO,
+    "noncanonical": x86_model.X86NonCanonicalAddress,
 }
 
 EXECUTORS = {

--- a/src/x86/x86_model.py
+++ b/src/x86/x86_model.py
@@ -357,7 +357,7 @@ class X86UnicornOOO(X86FaultModelAbstract):
 
     def __init__(self, *args):
         super().__init__(*args)
-        self.relevant_faults.update([12, 13])
+        self.relevant_faults.update([12, 13, 6])
         self.dependencies = set()
         self.dependency_checkpoints = []
 


### PR DESCRIPTION
This PR addresses the following issues:

- "ooo-gp" and "noncanonical" refer to the same contract.
- Rename `X86NonCanonicalOOO` to `X86NonCanonicalAddress` since it does not inherit from 'OOO' contract anymore.
- `X86NonCanonicalAddress` is not functional

Changes:

- remove "ooo-gp"
- Fix `X86NonCanonicalAddress`