### PR TITLE
fix: soft lookup bug

### DIFF
--- a/src/x86/executor/measurement.c
+++ b/src/x86/executor/measurement.c
@@ -285,8 +285,10 @@ void run_experiment(long rounds)
             faulty_page_pte.pte =
                 ((faulty_page_ptep->pte | faulty_pte_mask_set) & faulty_pte_mask_clear);
             set_pte_at(current->mm, faulty_page_addr, faulty_page_ptep, faulty_page_pte);
-            asm volatile("clflush (%0)\nlfence\n" ::"r"(faulty_page_addr)
-             : "memory");
+            // When testing for #PF flushing the faulty page causes a 'soft
+            // lookup' kernel error on certain CPUs.
+            //asm volatile("clflush (%0)\nlfence\n" ::"r"(faulty_page_addr)
+            // : "memory");
             _native_page_invalidate();
         }
 


### PR DESCRIPTION
While testing page faults the kernel crashes with error message:
```
watchdog: BUG: soft lockup - CPU#1 stuck for 22s! [lscpu:1969]
```

This PR fixes the bug. 