### PR TITLE
Software Interrupts + fixed tests

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -12,7 +12,7 @@ import copy
 import re
 
 from unicorn import Uc, UcError, UC_MEM_WRITE, UC_MEM_READ, UC_SECOND_SCALE, UC_HOOK_MEM_READ, \
-    UC_HOOK_MEM_WRITE, UC_HOOK_CODE, UC_PROT_NONE, UC_PROT_READ
+    UC_HOOK_MEM_WRITE, UC_HOOK_CODE
 
 from interfaces import CTrace, TestCase, Model, InputTaint, Instruction, ExecutionTrace, \
      TracedInstruction, TracedMemAccess, Input, Tracer, \
@@ -168,6 +168,8 @@ class UnicornModel(Model, ABC):
 
         # update a list of handled faults based on the config
         if 'DE-zero' in CONF.permitted_faults or 'DE-overflow' in CONF.permitted_faults:
+            self.handled_faults.append(21)
+        if 'BP' in CONF.permitted_faults:
             self.handled_faults.append(21)
         if 'UD' in CONF.permitted_faults:
             self.handled_faults.append(10)
@@ -495,8 +497,6 @@ class GPRTracer(UnicornTracer):
 # ==================================================================================================
 # Implementation of Execution Clauses
 # ==================================================================================================
-
-
 class UnicornSeq(UnicornModel):
     """
     A simple, in-order contract.

--- a/src/model.py
+++ b/src/model.py
@@ -130,7 +130,7 @@ class UnicornModel(Model, ABC):
     execution_tracing_enabled: bool = False
 
     # fault handling
-    handled_faults: List[int]
+    handled_faults: Set[int]
     pending_fault_id: int = 0
     previous_context = None
     rw_protect: bool = False
@@ -164,25 +164,27 @@ class UnicornModel(Model, ABC):
 
         # fault handling
         self.pending_fault_id = 0
-        self.handled_faults = []
+        self.handled_faults = set()
 
         # update a list of handled faults based on the config
         if 'DE-zero' in CONF.permitted_faults or 'DE-overflow' in CONF.permitted_faults:
-            self.handled_faults.append(21)
+            self.handled_faults.add(21)
+        if 'DB-instruction' in CONF.permitted_faults:
+            self.handled_faults.add(10)
         if 'BP' in CONF.permitted_faults:
-            self.handled_faults.append(21)
+            self.handled_faults.add(21)
         if 'UD' in CONF.permitted_faults:
-            self.handled_faults.append(10)
+            self.handled_faults.add(10)
         if 'PF-present' in CONF.permitted_faults:
-            self.handled_faults.extend([12, 13])
+            self.handled_faults.update([12, 13])
         if 'PF-writable' in CONF.permitted_faults:
-            self.handled_faults.append(12)
+            self.handled_faults.add(12)
         if 'PF-noncanonical' in CONF.permitted_faults:
-            self.handled_faults.append(6)
+            self.handled_faults.add(6)
         if 'assist-dirty' in CONF.permitted_faults:
-            self.handled_faults.extend([12, 13])
+            self.handled_faults.update([12, 13])
         if 'assist-accessed' in CONF.permitted_faults:
-            self.handled_faults.extend([12, 13])
+            self.handled_faults.update([12, 13])
 
     def load_test_case(self, test_case: TestCase) -> None:
         """

--- a/src/x86/executor/main.h
+++ b/src/x86/executor/main.h
@@ -105,8 +105,8 @@ extern volatile size_t n_inputs;
 
 // Fault handling
 #define HANDLED_FAULTS_DEFAULT                                                                     \
-    ((1 << X86_TRAP_DE) + (1 << X86_TRAP_BP) + (1 << X86_TRAP_UD) + (1 << X86_TRAP_GP) +           \
-     (1 << X86_TRAP_PF))
+    ((1 << X86_TRAP_DE) + (1 << X86_TRAP_DB) + (1 << X86_TRAP_BP) + (1 << X86_TRAP_UD) +           \
+     (1 << X86_TRAP_GP) + (1 << X86_TRAP_PF))
 
 extern char *fault_handler;
 extern uint32_t handled_faults;

--- a/src/x86/executor/main.h
+++ b/src/x86/executor/main.h
@@ -6,8 +6,8 @@
 #ifndef X86_EXECUTOR
 #define X86_EXECUTOR
 
-#include <linux/types.h>
 #include <asm/traps.h>
+#include <linux/types.h>
 
 #define DEBUG 0
 #define STRINGIFY(...) #__VA_ARGS__
@@ -104,9 +104,12 @@ extern uint64_t *inputs;
 extern volatile size_t n_inputs;
 
 // Fault handling
+#define HANDLED_FAULTS_DEFAULT                                                                     \
+    ((1 << X86_TRAP_DE) + (1 << X86_TRAP_BP) + (1 << X86_TRAP_UD) + (1 << X86_TRAP_GP) +           \
+     (1 << X86_TRAP_PF))
+
 extern char *fault_handler;
 extern uint32_t handled_faults;
-#define HANDLED_FAULTS_DEFAULT 24641 // #DE #IO #PF #GP
 extern gate_desc *curr_idt_table;
 extern pteval_t faulty_pte_mask_set;
 extern pteval_t faulty_pte_mask_clear;

--- a/src/x86/isa_spec/get_spec.py
+++ b/src/x86/isa_spec/get_spec.py
@@ -85,6 +85,9 @@ class X86Transformer:
         'FS': 16,
         'GS': 16,
     }
+    not_control_flow = ["INT", "INT1", "INT3", "INTO"]
+    """ a list of instructions that have RIP as an operand but should
+    not be considered as control-flow instructions by the generator"""
 
     def __init__(self) -> None:
         self.instructions = []
@@ -124,7 +127,7 @@ class X86Transformer:
                     op_type = op_node.attrib['type']
                     if op_type == 'reg':
                         parsed_op = self.parse_reg_operand(op_node)
-                        if op_node.text == "RIP":
+                        if op_node.text == "RIP" and name not in self.not_control_flow:
                             self.instruction.control_flow = True
                     elif op_type == 'mem':
                         parsed_op = self.parse_mem_operand(op_node)

--- a/src/x86/tests/unit_model.py
+++ b/src/x86/tests/unit_model.py
@@ -327,7 +327,7 @@ class X86ModelTest(unittest.TestCase):
         mbase, cbase = 0x1000000, 0x8000
         model = x86_model.X86UnicornSeq(mbase, cbase)
         model.tracer = core_model.CTTracer()
-        model.handled_faults.extend([12, 13])
+        model.handled_faults.update([12, 13])
         input_ = Input()
         input_[0] = 1
         input_[input_.register_start + 2] = 4096
@@ -340,7 +340,7 @@ class X86ModelTest(unittest.TestCase):
         model = x86_model.X86UnicornNull(mbase, cbase)
         model.tracer = core_model.CTTracer()
         model.rw_protect = True
-        model.handled_faults.extend([12, 13])
+        model.handled_faults.update([12, 13])
         input_ = Input()
         for i in range(0, 7):
             input_[input_.register_start + i] = 2
@@ -369,7 +369,7 @@ class X86ModelTest(unittest.TestCase):
         mbase, cbase = 0x1000000, 0x8000
         model = x86_model.X86UnicornNullTerminating(mbase, cbase)
         model.tracer = core_model.CTTracer()
-        model.handled_faults.extend([12, 13])
+        model.handled_faults.update([12, 13])
         input_ = Input()
         for i in range(0, 7):
             input_[input_.register_start + i] = 2
@@ -401,7 +401,7 @@ class X86ModelTest(unittest.TestCase):
         mbase, cbase = 0x1000000, 0x8000
         model = x86_model.X86UnicornOOO(mbase, cbase)
         model.tracer = core_model.CTTracer()
-        model.handled_faults.extend([12, 13])
+        model.handled_faults.update([12, 13])
         input_ = Input()
         for i in range(0, 7):
             input_[input_.register_start + i] = 2
@@ -421,7 +421,7 @@ class X86ModelTest(unittest.TestCase):
         mbase, cbase = 0x1000000, 0x8000
         model = x86_model.X86UnicornDivZero(mbase, cbase)
         model.tracer = core_model.CTTracer()
-        model.handled_faults.append(21)
+        model.handled_faults.update(21)
         input_ = Input()
         input_[input_.register_start] = 2  # rax
         input_[input_.register_start + 1] = 0  # rbx
@@ -435,7 +435,7 @@ class X86ModelTest(unittest.TestCase):
         model = x86_model.X86UnicornDivZero(mbase, cbase)
         model.tracer = core_model.CTTracer()
         model.rw_protect = True
-        model.handled_faults.append(21)
+        model.handled_faults.update(21)
         input_ = Input()
         input_[input_.register_start] = 2  # rax
         input_[input_.register_start + 1] = 0  # rbx
@@ -453,7 +453,7 @@ class X86ModelTest(unittest.TestCase):
         mbase, cbase = 0x1000000, 0x8000
         model = x86_model.X86Meltdown(mbase, cbase)
         model.tracer = core_model.CTTracer()
-        model.handled_faults.extend([12, 13])
+        model.handled_faults.update([12, 13])
         input_ = Input()
         for i in range(0, 7):
             input_[input_.register_start + i] = 2
@@ -474,7 +474,7 @@ class X86ModelTest(unittest.TestCase):
         model = x86_model.X86Meltdown(mbase, cbase)
         model.tracer = core_model.CTTracer()
         model.rw_protect = True
-        model.handled_faults.extend([12, 13])
+        model.handled_faults.update([12, 13])
         input_ = Input()
         for i in range(0, 7):
             input_[input_.register_start + i] = 2
@@ -495,7 +495,7 @@ class X86ModelTest(unittest.TestCase):
         model = x86_model.X86Meltdown(mbase, cbase)
         model.tracer = core_model.CTTracer()
         model.rw_protect = True
-        model.handled_faults.extend([12, 13])
+        model.handled_faults.update([12, 13])
         input_ = Input()
         for i in range(0, 7):
             input_[input_.register_start + i] = 2
@@ -517,7 +517,7 @@ class X86ModelTest(unittest.TestCase):
         model = x86_model.X86CondMeltdown(mbase, cbase)
         model.tracer = core_model.CTTracer()
         model.rw_protect = True
-        model.handled_faults.extend([12, 13])
+        model.handled_faults.update([12, 13])
         input_ = Input()
         for i in range(0, 7):
             input_[input_.register_start + i] = 2
@@ -540,7 +540,7 @@ class X86ModelTest(unittest.TestCase):
         model = x86_model.X86CondMeltdown(mbase, cbase)
         model.tracer = core_model.CTTracer()
         model.rw_protect = True
-        model.handled_faults.extend([12, 13])
+        model.handled_faults.update([12, 13])
         input_ = Input()
         for i in range(0, 7):
             input_[input_.register_start + i] = 2
@@ -568,7 +568,7 @@ class X86ModelTest(unittest.TestCase):
         mbase, cbase = 0x1000000, 0x8000
         model = x86_model.X86FaultSkip(mbase, cbase)
         model.tracer = core_model.CTTracer()
-        model.handled_faults.extend([12, 13])
+        model.handled_faults.update([12, 13])
         input_ = Input()
         for i in range(0, 7):
             input_[input_.register_start + i] = 2

--- a/src/x86/x86_config.py
+++ b/src/x86/x86_config.py
@@ -11,7 +11,7 @@ x86_option_values = {
     'executor_mode': ['P+P', 'F+R', 'E+R'],  # 'GPR' is intentionally left out
     'permitted_faults': [
         'DE-zero', 'DE-overflow', 'UD', 'PF-present', 'PF-writable', 'PF-noncanonical', 'BP',
-        'assist-accessed', 'assist-dirty'
+        'DB-instruction', 'assist-accessed', 'assist-dirty'
     ],
 }
 
@@ -20,7 +20,6 @@ x86_executor_enable_prefetcher: bool = False
 x86_executor_enable_ssbp_patch: bool = True
 """ x86_executor_enable_ssbp_patch: enable a patch against Speculative Store Bypass"""
 x86_disable_div64: bool = True
-
 
 x86_instruction_categories: List[str] = [
     # Base x86 - main instructions
@@ -98,7 +97,7 @@ x86_instruction_blocklist: List[str] = [
     "REPNE CMPSB", "REPNE CMPSD", "REPNE CMPSW", "REPNE CMPSQ",
     "REPNE MOVSB", "REPNE MOVSD", "REPNE MOVSW", "REPNE MOVSQ",
 
-    "INT", "INTO", "INT1",  # under construction
+    "INT", "INTO",  # under construction
 
     # - not supported
     "LFENCE", "MFENCE", "SFENCE", "CLFLUSH", "CLFLUSHOPT",

--- a/src/x86/x86_config.py
+++ b/src/x86/x86_config.py
@@ -77,6 +77,8 @@ x86_instruction_blocklist: List[str] = [
     "XLAT", "XLATB",
     # - Requires complex instrumentation
     "ENTERW", "ENTER", "LEAVEW", "LEAVE",
+    # - requires support of all possible interrupts
+    "INT",
 
     # Stringops - under construction
     "LODSB", "LODSD", "LODSW", "LODSQ",
@@ -96,8 +98,6 @@ x86_instruction_blocklist: List[str] = [
     "REPNE STOSB", "REPNE STOSD", "REPNE STOSW", "REPNE STOSQ",
     "REPNE CMPSB", "REPNE CMPSD", "REPNE CMPSW", "REPNE CMPSQ",
     "REPNE MOVSB", "REPNE MOVSD", "REPNE MOVSW", "REPNE MOVSQ",
-
-    "INT", "INTO",  # under construction
 
     # - not supported
     "LFENCE", "MFENCE", "SFENCE", "CLFLUSH", "CLFLUSHOPT",

--- a/src/x86/x86_config.py
+++ b/src/x86/x86_config.py
@@ -10,7 +10,7 @@ from typing import List
 x86_option_values = {
     'executor_mode': ['P+P', 'F+R', 'E+R'],  # 'GPR' is intentionally left out
     'permitted_faults': [
-        'DE-zero', 'DE-overflow', 'UD', 'PF-present', 'PF-writable', 'PF-noncanonical',
+        'DE-zero', 'DE-overflow', 'UD', 'PF-present', 'PF-writable', 'PF-noncanonical', 'BP',
         'assist-accessed', 'assist-dirty'
     ],
 }
@@ -23,7 +23,7 @@ x86_disable_div64: bool = True
 
 
 x86_instruction_categories: List[str] = [
-    # Base x86
+    # Base x86 - main instructions
     "BASE-BINARY",
     "BASE-BITBYTE",
     "BASE-CMOV",
@@ -40,6 +40,9 @@ x86_instruction_categories: List[str] = [
     "BASE-SETCC",
     "BASE-STRINGOP",
 
+    # Base x86 - system instructions
+    "BASE-INTERRUPT",
+
     # "BASE-ROTATE",      # Unknown bug in Unicorn - emulated incorrectly
     # "BASE-SHIFT",       # Unknown bug in Unicorn - emulated incorrectly
 
@@ -48,7 +51,6 @@ x86_instruction_categories: List[str] = [
     # "BASE-RET",         # Not supported: Complex control flow
 
     # "BASE-SEGOP",       # Not supported: System instructions
-    # "BASE-INTERRUPT",   # Not supported: System instructions
     # "BASE-IO",          # Not supported: System instructions
     # "BASE-IOSTRINGOP",  # Not supported: System instructions
     # "BASE-SYSCALL",     # Not supported: System instructions
@@ -95,6 +97,8 @@ x86_instruction_blocklist: List[str] = [
     "REPNE STOSB", "REPNE STOSD", "REPNE STOSW", "REPNE STOSQ",
     "REPNE CMPSB", "REPNE CMPSD", "REPNE CMPSW", "REPNE CMPSQ",
     "REPNE MOVSB", "REPNE MOVSD", "REPNE MOVSW", "REPNE MOVSQ",
+
+    "INT", "INTO", "INT1",  # under construction
 
     # - not supported
     "LFENCE", "MFENCE", "SFENCE", "CLFLUSH", "CLFLUSHOPT",

--- a/src/x86/x86_fuzzer.py
+++ b/src/x86/x86_fuzzer.py
@@ -27,6 +27,8 @@ def update_instruction_list():
             CONF._default_instruction_blocklist.append("REX IDIV")
     if 'UD' not in CONF.permitted_faults:
         CONF._default_instruction_blocklist.extend(["UD", "UD2"])
+    if 'BP' not in CONF.permitted_faults:
+        CONF._default_instruction_blocklist.extend(["INT3"])
 
 
 class X86Fuzzer(Fuzzer):

--- a/src/x86/x86_fuzzer.py
+++ b/src/x86/x86_fuzzer.py
@@ -27,8 +27,10 @@ def update_instruction_list():
             CONF._default_instruction_blocklist.append("REX IDIV")
     if 'UD' not in CONF.permitted_faults:
         CONF._default_instruction_blocklist.extend(["UD", "UD2"])
+    if 'DB-instruction' not in CONF.permitted_faults:
+        CONF._default_instruction_blocklist.append("INT1")
     if 'BP' not in CONF.permitted_faults:
-        CONF._default_instruction_blocklist.extend(["INT3"])
+        CONF._default_instruction_blocklist.append("INT3")
 
 
 class X86Fuzzer(Fuzzer):


### PR DESCRIPTION
This PR includes:
* adds support for #BP and #DB
* when testing instruction-triggered faults, check for presence of the corresponding instructions in the instruction set
* refactoring: UnicornModel.handled_faults is now a set instead of a list
* fixed failing tests