### PR TITLE
Exception handling

### DIFF
--- a/src/x86/x86_model.py
+++ b/src/x86/x86_model.py
@@ -492,6 +492,7 @@ class X86UnicornOOO(X86FaultModelAbstract):
         self.dependencies = self.dependency_checkpoints.pop()
         return super().rollback()
 
+
 class X86UnicornVSPECUnknown(X86FaultModelAbstract):
     """
     Contract for value speculation with unknown values
@@ -595,12 +596,12 @@ class X86UnicornVSPECUnknown(X86FaultModelAbstract):
                 reg_src_operands.extend(op.get_read_flags())
                 reg_dest_operands.extend(op.get_write_flags())                
         
-        # print('source operands:', reg_src_operands)  
-        # print('destination operands:', reg_dest_operands)        
+        # print('source operands:', reg_src_operands)
+        # print('destination operands:', reg_dest_operands)
               
         # if source operands are not tainted, possible taint from destination operands 
         #   can be removed and control flow is returned
-        # print('intersection: ', reg_src_operands | model.reg_taints.keys())
+        # print('intersection: ', reg_src_operands & model.reg_taints.keys())
         if not (reg_src_operands & model.reg_taints.keys()):
             for reg in reg_dest_operands:
                 if reg in model.reg_taints:
@@ -641,8 +642,6 @@ class X86UnicornVSPECUnknown(X86FaultModelAbstract):
         for reg in reg_dest_operands:
             model.reg_taints[reg] = source_taints
             
-        
-
     @staticmethod
     def trace_mem_access(emulator, access, address, size, value, model) -> None:
         assert isinstance(model, X86UnicornVSPECUnknown)
@@ -669,6 +668,7 @@ class X86UnicornVSPECUnknown(X86FaultModelAbstract):
     def rollback(self) -> int:
         self.reg_taints = self.reg_taints_checkpoints.pop()
         return super().rollback()
+
 
 class X86UnicornDivZero(X86FaultModelAbstract):
     injected_value: int = 0
@@ -799,9 +799,6 @@ class X86Meltdown(X86FaultModelAbstract):
                                   self.FAULTY_REGION_SIZE)
 
         return self.curr_instruction_addr
-    
-class X86CondMeltdown(X86Meltdown, X86UnicornCond):
-    pass
 
 
 class X86CondMeltdown(X86Meltdown, X86UnicornCond):

--- a/src/x86/x86_model.py
+++ b/src/x86/x86_model.py
@@ -552,6 +552,7 @@ class X86UnicornVSPECUnknown(X86FaultModelAbstract):
         # taint destination registers with taints
         for reg in reg_dest_operands:
             self.reg_taints[reg] = source_values
+        # print(f"Dest taints:{self.reg_taints}")
          
         # speculatively skip the faulting instruction
         if self.next_instruction_addr >= self.code_end:
@@ -565,7 +566,6 @@ class X86UnicornVSPECUnknown(X86FaultModelAbstract):
         Track how taints move through system and produce correct observations.
         """
         assert isinstance(model, X86UnicornVSPECUnknown)
-
         # reset flag
         model.curr_observation = set()
         # print('current taints:', model.reg_taints)
@@ -637,11 +637,13 @@ class X86UnicornVSPECUnknown(X86FaultModelAbstract):
                 reg_id = X86UnicornTargetDesc.reg_decode[reg]
                 reg_value = model.emulator.reg_read(reg_id)
                 source_taints.add(reg_value)
+            # print(f"Source taints:{source_taints}")
         
         # taint destination registers with new taints
         #   old taint can be overwritten
         for reg in reg_dest_operands:
             model.reg_taints[reg] = source_taints
+        # print(f"Dest taints:{model.reg_taints}")
             
     @staticmethod
     def trace_mem_access(emulator, access, address, size, value, model) -> None:
@@ -657,8 +659,8 @@ class X86UnicornVSPECUnknown(X86FaultModelAbstract):
             # print('memory access with observation:', model.curr_observation)
             # observation_hash =  model.curr_observation.pop()
             # print('hash:', observation_hash)
-            model.tracer.observe_mem_access(access, observation_hash, size, 1, model)
-            # model.tracer.trace.append(model.sandbox_base + model.default_taint)
+            model.tracer.observe_mem_access(access, address, size, 1, model)
+            model.tracer.trace.append(observation_hash)
         else:
             X86FaultModelAbstract.trace_mem_access(emulator, access, address, size, value, model)
 

--- a/src/x86/x86_model.py
+++ b/src/x86/x86_model.py
@@ -499,7 +499,6 @@ class X86UnicornVSPECUnknown(X86FaultModelAbstract):
     """
     reg_taints: Dict
     flag_taints: Dict
-    address_taints: Dict
     reg_taints_checkpoints: List[Dict]
     curr_observation : Set = set()
 
@@ -509,8 +508,14 @@ class X86UnicornVSPECUnknown(X86FaultModelAbstract):
         self.relevant_faults.update([21])
         self.reg_taints = dict()
         self.flag_taints = dict()
-        self.address_taints = dict()
         self.reg_taints_checkpoints = []
+
+    def _load_input(self, input_: Input):
+        self.curr_observation.clear()
+        assert(len(self.reg_taints) == 0)
+        assert(len(self.flag_taints) == 0)
+        assert(len(self.reg_taints_checkpoints) == 0)
+        return super()._load_input(input_)
 
     def speculate_fault(self, errno: int) -> int:
         if not self.fault_triggers_speculation(errno):

--- a/src/x86/x86_model.py
+++ b/src/x86/x86_model.py
@@ -501,7 +501,7 @@ class X86UnicornVSPECUnknown(X86FaultModelAbstract):
     flag_taints: Dict
     address_taints: Dict
     reg_taints_checkpoints: List[Dict]
-    curr_observation: set()
+    curr_observation : Set = set()
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -627,7 +627,7 @@ class X86UnicornVSPECUnknown(X86FaultModelAbstract):
             ## to be implemented
 
         # if not a memory operation, propagate taints
-        source_taints = set()
+        source_taints : Set = set()
         for reg in reg_src_operands:
             # if register is tainted, then value is unknown, so add taint to set
             #   else, add value of register to taint set


### PR DESCRIPTION
Fix for the `X86UnicornVSPECUnknown`.  

- The contracts failed to execute because `trace_mem_access` calls `observe_mem_access` passing the `curr_observation` hash as address, which is invalid.
Instead we add the `curr_observation` to the trace but we call  `observe_mem_access` only on the current address.
- We use Set rather than Lists to hold tainted values so that we have built-in operators for intersection and unions operations
- Fixing styles and spacing
