### PR TITLE
Exception handling

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -181,7 +181,7 @@ class UnicornModel(Model, ABC):
         if 'PF-writable' in CONF.permitted_faults:
             self.handled_faults.add(12)
         if 'PF-noncanonical' in CONF.permitted_faults:
-            self.handled_faults.update([6,7])
+            self.handled_faults.update([6, 7])
         if 'assist-dirty' in CONF.permitted_faults:
             self.handled_faults.update([12, 13])
         if 'assist-accessed' in CONF.permitted_faults:

--- a/src/model.py
+++ b/src/model.py
@@ -182,7 +182,7 @@ class UnicornModel(Model, ABC):
             self.handled_faults.update([12, 13])
         if 'PF-writable' in CONF.permitted_faults:
             self.handled_faults.add(12)
-        if 'PF-noncanonical' in CONF.permitted_faults:
+        if 'GP-noncanonical' in CONF.permitted_faults:
             self.handled_faults.update([6, 7])
         if 'assist-dirty' in CONF.permitted_faults:
             self.handled_faults.update([12, 13])

--- a/src/model.py
+++ b/src/model.py
@@ -181,7 +181,7 @@ class UnicornModel(Model, ABC):
         if 'PF-writable' in CONF.permitted_faults:
             self.handled_faults.add(12)
         if 'PF-noncanonical' in CONF.permitted_faults:
-            self.handled_faults.add(6)
+            self.handled_faults.update([6,7])
         if 'assist-dirty' in CONF.permitted_faults:
             self.handled_faults.update([12, 13])
         if 'assist-accessed' in CONF.permitted_faults:

--- a/src/x86/x86_config.py
+++ b/src/x86/x86_config.py
@@ -10,7 +10,7 @@ from typing import List
 x86_option_values = {
     'executor_mode': ['P+P', 'F+R', 'E+R'],  # 'GPR' is intentionally left out
     'permitted_faults': [
-        'DE-zero', 'DE-overflow', 'UD', 'UD-sgx', 'PF-present', 'PF-writable', 'PF-noncanonical',
+        'DE-zero', 'DE-overflow', 'UD', 'UD-sgx', 'PF-present', 'PF-writable', 'GP-noncanonical',
         'BP', 'DB-instruction', 'assist-accessed', 'assist-dirty'
     ],
 }

--- a/src/x86/x86_generator.py
+++ b/src/x86/x86_generator.py
@@ -285,7 +285,7 @@ class X86LFENCEPass(Pass):
 class X86NonCanonicalAddressPass(Pass):
 
     def run_on_test_case(self, test_case: TestCase) -> None:
-        if 'PF-noncanonical' not in CONF.permitted_faults:
+        if 'GP-noncanonical' not in CONF.permitted_faults:
             return
 
         for func in test_case.functions:

--- a/src/x86/x86_generator.py
+++ b/src/x86/x86_generator.py
@@ -329,13 +329,14 @@ class X86NonCanonicalAddressPass(Pass):
                                X86TargetDesc.gpr_normalized[reg.value]:
                                 mask_reg = masks[1]
 
+                        mask = hex((random.getrandbits(16) << 48))
                         lea = Instruction("LEA", True) \
                             .add_op(RegisterOperand(offset_reg, 64, False, True)) \
                             .add_op(MemoryOperand(registers, 64, True, False))
                         bb.insert_before(instr, lea)
                         mov = Instruction("MOV", True) \
                             .add_op(RegisterOperand(mask_reg, 64, True, True)) \
-                            .add_op(ImmediateOperand("0x1000000000000", 64))
+                            .add_op(ImmediateOperand(mask, 64))
                         bb.insert_before(instr, mov)
                         mask = Instruction("XOR", True) \
                             .add_op(RegisterOperand(offset_reg, 64, True, True)) \
@@ -344,6 +345,10 @@ class X86NonCanonicalAddressPass(Pass):
                         for idx, op in enumerate(instr.operands):
                             if op == mem_operand:
                                 instr.operands[idx].value = offset_reg
+
+                    # Make sure #GP only once. Otherwise Unicorn keeps raising an exception
+                    # when rolling back to the end of the code
+                    return
 
 
 class X86SandboxPass(Pass):

--- a/src/x86/x86_model.py
+++ b/src/x86/x86_model.py
@@ -859,7 +859,7 @@ class X86NonCanonicalAddress(X86FaultModelAbstract):
 
     def __init__(self, *args):
         super().__init__(*args)
-        self.relevant_faults.update([6])
+        self.relevant_faults.update([6,7])
 
     def speculate_fault(self, errno: int) -> int:
         if not self.fault_triggers_speculation(errno):

--- a/src/x86/x86_model.py
+++ b/src/x86/x86_model.py
@@ -855,7 +855,7 @@ class X86NonCanonicalAddress(X86FaultModelAbstract):
     """
      Load from non-canonical addresss
     """
-    fault_inst_addr: int
+    last_faulty_addr: int
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -865,6 +865,7 @@ class X86NonCanonicalAddress(X86FaultModelAbstract):
         if not self.fault_triggers_speculation(errno):
             return 0
 
+        print(f"Checkpoint at {self.code_end:x}")
         self.checkpoint(self.emulator, self.code_end)
         self.last_faulty_addr = self.curr_instruction_addr
         return self.curr_instruction_addr

--- a/src/x86/x86_model.py
+++ b/src/x86/x86_model.py
@@ -883,15 +883,14 @@ class X86NonCanonicalAddress(X86FaultModelAbstract):
 
             uc_reg = X86UnicornTargetDesc.reg_str_to_constant[registers[0]]
             address = model.emulator.reg_read(uc_reg)  # load address
-
-            print(f"old: {address:x}")
-            if address & (1 << 48):  # bit 48 is 1 => high address
+            if address & (1 << 47):  # bit 48 is 1 => high address
+                # print(f"High address {address:x}")
                 address = address | 0xFFFF800000000000
             else:  # bit 48 is 0 => low address
+                # print(f"Low address: {address:x}")
                 address = address & 0x00007FFFFFFFFFF
-                print(f"Canonical: {address:x}")
-                model.emulator.reg_write(uc_reg, address)
-                return  # Continue execution with canonical address
+            model.emulator.reg_write(uc_reg, address)
+            return  # Continue execution with canonical address
 
         return
 


### PR DESCRIPTION
This contract is violated but the PR makes the implementation compliant with the contract.
1. Upon a store on non-canonical address Unicorn returns error code 7.
2. In the contract we set all the bits above index 48 as the bit at index 48 to make the address canonical again and emulate transient execution.
In the generator:
1. In the generator we flip any random bit above index 48.
2. We return after making an address non-canonical. If two loads to a non-canonical address are inserted in the test case Unicorn 1.0.2+ keeps raising an exception, Unicorn 1.0.3 silently fails and stops emulation. I haven't found a workaround to this yet.    
