### PR TITLE
generator: ensure generation of conditional branches

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -47,11 +47,11 @@ class ConfCls:
     """ max_bb_per_function: maximum number of basic blocks per function in generated programs """
     register_blocklist: List[str] = []
     """ register_blocklist: list of registers that will NOT be used for generating programs """
-    place_adjacent_unconditional_branches: bool = False
+    place_adjacent_unconditional_branches: bool = True
     """ place_adjacent_unconditional_branches: decides whether or not unconditional branches between
     two adjacent basic blocks should be placed.
     (Example: placing an unconditional branch from BB2 --> BB3 at the end of BB2) """
-    conditional_branch_selection_attempts: int = 2
+    conditional_branch_selection_attempts: int = 1
     """ conditional_branch_selection_attempts: the number of times to attempt randomly generating
     a conditional branch instruction (instead of an UNconditional branch) for extra basic block
     terminators that aren't "adjacent unconditional branches" (see

--- a/src/config.py
+++ b/src/config.py
@@ -47,6 +47,23 @@ class ConfCls:
     """ max_bb_per_function: maximum number of basic blocks per function in generated programs """
     register_blocklist: List[str] = []
     """ register_blocklist: list of registers that will NOT be used for generating programs """
+    place_adjacent_unconditional_branches: bool = False
+    """ place_adjacent_unconditional_branches: decides whether or not unconditional branches between
+    two adjacent basic blocks should be placed.
+    (Example: placing an unconditional branch from BB2 --> BB3 at the end of BB2) """
+    conditional_branch_selection_attempts: int = 2
+    """ conditional_branch_selection_attempts: the number of times to attempt randomly generating
+    a conditional branch instruction (instead of an UNconditional branch) for extra basic block
+    terminators that aren't "adjacent unconditional branches" (see
+    'place_adjacent_unconditional_branches' to learn what these are).
+        - Set to a positive integer, X, to have the program generator attempt to generate
+          conditional branches X times for each extra terminator. (After X times, it gives up and
+          chooses an UNconditional branch.)
+        - Set to 0 to NEVER generate any conditional branches in generated programs.
+        - Set to -1 to ALWAYS generate conditional branches for these kinds of terminators.
+    TL;DR - adjust this number to increase or decrease the number of conditional branches that
+    appear in generated programs.
+    """
     avoid_data_dependencies: bool = False
     """ [DEPRECATED] avoid_data_dependencies: """
     generate_memory_accesses_in_pairs: bool = False

--- a/src/config.py
+++ b/src/config.py
@@ -59,23 +59,6 @@ class ConfCls:
     for correctness """
     register_blocklist: List[str] = []
     """ register_blocklist: list of registers that will NOT be used for generating programs """
-    place_adjacent_unconditional_branches: bool = True
-    """ place_adjacent_unconditional_branches: decides whether or not unconditional branches between
-    two adjacent basic blocks should be placed.
-    (Example: placing an unconditional branch from BB2 --> BB3 at the end of BB2) """
-    conditional_branch_selection_attempts: int = 1
-    """ conditional_branch_selection_attempts: the number of times to attempt randomly generating
-    a conditional branch instruction (instead of an UNconditional branch) for extra basic block
-    terminators that aren't "adjacent unconditional branches" (see
-    'place_adjacent_unconditional_branches' to learn what these are).
-        - Set to a positive integer, X, to have the program generator attempt to generate
-          conditional branches X times for each extra terminator. (After X times, it gives up and
-          chooses an UNconditional branch.)
-        - Set to 0 to NEVER generate any conditional branches in generated programs.
-        - Set to -1 to ALWAYS generate conditional branches for these kinds of terminators.
-    TL;DR - adjust this number to increase or decrease the number of conditional branches that
-    appear in generated programs.
-    """
     avoid_data_dependencies: bool = False
     """ [DEPRECATED] avoid_data_dependencies: """
     generate_memory_accesses_in_pairs: bool = False


### PR DESCRIPTION
This PR implements two new config fields that give the user better control over the program generator's branch placement. (This seeks to resolve issue #37). Here's a description of what these new fields do:

### New Config Field 1 - `conditional_branch_selection_attempts`

The program generator uses an internal list of control-flow instruction specifications to generate random branch instructions at the end of basic blocks. This internal list contains both conditional *and* unconditional branches. So, when a random control-flow instruction is generated, it's possible either type will be produced.

The `conditional_branch_selection_attempts` config field helps control this. This PR adds a loop to the program generator that is controlled by this field. When generating a random control-flow instruction, this loop will:

* (If the field is set to a positive integer, `X`) Repeatedly generate control-flow instructions `X` number of times until a conditional branch is found.
* (If the field is set to `-1`) Repeatedly generate control-flow instructions, forever, until a conditional branch is found.
* (If the field is set to `0`) Don't bother looking for a conditional branch; always use unconditional branches.

### New Config Field 2 - `place_adjacent_unconditional_branches`

(This doesn't address issue #37, but it was trivial to implement and some may find it useful.) By default, the program generator places an unconditional branch instruction at the end of each basic block that targets the next-adjacent basic block. For example:

```python
# ... code
.bb_main.2:
# ... code
B .bb_main.3 # jump to BB3
.bb_main.3: # BB3 appears immediately after
# ... code
```

Now, `place_adjacent_unconditional_branches` controls whether or not this happens. It's `true` by default (to maintain the original behavior), but setting it to `false` will prevent these unconditional-branches-to-the-next-adjacent-basic-block from being placed.