### PR TITLE
Generator Gadgets

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -47,6 +47,8 @@ For a complete list, see `src/config.py`.
   Will use a random seed if set to zero.
 * `min_bb_per_function` [int]: Minimum number of basic blocks per test case.
 * `max_bb_per_function` [int]: Maximum number of basic blocks per test case.
+* `min_successors_per_bb` [int]: Minimum number of successors for each basic block.
+* `max_successors_per_bb` [int]: Maximum number of successors for each basic block.
 * `program_size` [int]: Number of instructions per test case.
   The actual size might be larger because of the instrumentation.
 * `avg_mem_accesses` [int]: Average number of memory accesses per test case.
@@ -54,6 +56,27 @@ For a complete list, see `src/config.py`.
   Used to filter out instructions from the instruction set file passed via command line (`--instruction-set`).
 * `instruction_blocklist` [list(str)]: List of instructions to be excluded by the generator.
   Used to filter out instructions from the instruction set file passed via command line (`--instruction-set`).
+* `gadget_file` [str]: The path to a user-defined "gadget" file.  See below for a description of gadgets.
+* `avg_gadgets_per_bb` [float]: A number used to increase or decrease the amount of gadgets that are placed into generated programs.
+* `max_gadgets_per_bb` [int]: A hard maximum for the number of gadgets to be placed inside each basic block.
+
+## Gadgets
+
+Revizor's program generator allows for the optional specification of a "gadget file" containing
+user-defined code gadgets. A **gadget** is a small collection of assembly instructions in a specific
+order. Certain combinations of assembly instructions may create interesting behavior on the target
+CPU, but it's often very rare for this combination to be generated with the program generator's
+purely-random instruction placement. This is why gadgets are supported.
+
+The gadget file allows for the user of Revizor to specify one or more interseting combinations of
+instructions (**gadgets**) that Revizor will use during program generation. Randomly, the program
+generator will place a gadget into a basic block, rather than a random instruction.
+
+The frequency of gadgets in generated programs can be tuned with the `avg_gadgets_per_bb` and
+`max_gadgets_per_bb` config fields. Gadgets are specified as JSON, in the same format as the Revizor
+ISA specification JSON file. Each gadget has a name, and optionally, a weight used to further tune
+the appearance of specific gadgets in generated programs.
+See `src/arm64/tests/example_gadgets.json` for an example of what a gadget file looks like.
 
 # Input Generator Configuration
 

--- a/src/arm64/arm64_generator.py
+++ b/src/arm64/arm64_generator.py
@@ -310,7 +310,9 @@ class ARMPrinter(Printer):
             operands = inst.operands
 
         operands_str = ", ".join([self.operand_to_str(op) for op in operands])
-        comment = "// instrumentation" if inst.is_instrumentation else ""
+        if inst.is_instrumentation:
+            inst.set_comment("instrumentation")
+        comment = ("// %s" % inst.comment) if inst.comment is not None else ""
         return f"{inst.name}{cond} {operands_str} {comment}"
 
     def operand_to_str(self, op: Operand) -> str:

--- a/src/arm64/tests/example_gadgets.json
+++ b/src/arm64/tests/example_gadgets.json
@@ -1,210 +1,72 @@
 [
     {
-        "name": "spectre_v1_double_load_x0",
-        "weight": 1.0,
+        "name": "mask16_cmp",
+        "description": "Masks the low 16 bits of two different registers, then compares them to set flags.",
+        "weight": 0.5,
+        "operand_aliases":
+        [
+            {
+                "name": "REG_A",
+                "operand": {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["GPR"]}
+            },
+            {
+                "name": "REG_B",
+                "operand": {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["GPR"]}
+            }
+        ],
         "instructions":
         [
             {
-                "name": "LDR",
+                "name": "AND",
                 "category": "general",
                 "control_flow": false,
                 "operands": [
-                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["X0"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64},
-                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
+                    {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["REG_A"]},
+                    {"dest": false, "src": true, "type_": "REG", "width": 32, "values": ["REG_A"]},
+                    {"dest": false, "src": true, "type_": "IMM", "values": ["[65535-65535]"]}
                 ],
-                "implicit_operands": []
+                "implicit_operands": [
+                    {"type_": "FLAGS", "width": 0, "src": false, "dest": false, "values": ["w", "", "", "w", "w", "", "", "", "w"]}
+                ]
             },
             {
-                "name": "LDR",
+                "name": "AND",
                 "category": "general",
                 "control_flow": false,
                 "operands": [
-                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["GPR"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64, "values": ["X0"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
+                    {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["REG_B"]},
+                    {"dest": false, "src": true, "type_": "REG", "width": 32, "values": ["REG_B"]},
+                    {"dest": false, "src": true, "type_": "IMM", "values": ["[65535-65535]"]}
                 ],
-                "implicit_operands": []
+                "implicit_operands": [
+                    {"type_": "FLAGS", "width": 0, "src": false, "dest": false, "values": ["w", "", "", "w", "w", "", "", "", "w"]}
+                ]
+            },
+            {
+                "name": "CMP",
+                "category": "general",
+                "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["REG_A"]},
+                    {"dest": false, "src": true, "type_": "REG", "width": 32, "values": ["REG_B"]}
+                ],
+                "implicit_operands": [
+                    {"type_": "FLAGS", "width": 0, "src": false, "dest": false, "values": ["w", "", "", "w", "w", "", "", "", "w"]}
+                ]
             }
         ]
     },
     {
-        "name": "spectre_v1_double_load_x1",
-        "weight": 1.0,
-        "instructions":
+        "name": "randreg_a13or9",
+        "description": "Pseudo-randomizes a register by ANDing with 13 and ORing with a right-rotation of itself.",
+        "weight": 0.35,
+        "operand_aliases":
         [
             {
-                "name": "LDR",
-                "category": "general",
-                "control_flow": false,
-                "operands": [
-                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["X1"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64},
-                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
-                ],
-                "implicit_operands": []
-            },
-            {
-                "name": "LDR",
-                "category": "general",
-                "control_flow": false,
-                "operands": [
-                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["GPR"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64, "values": ["X1"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
-                ],
-                "implicit_operands": []
+                "name": "REG_VICTIM",
+                "operand": {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["GPR"]}
             }
-        ]
-    },
-    {
-        "name": "spectre_v1_double_load_x2",
-        "weight": 1.0,
-        "instructions":
-        [
-            {
-                "name": "LDR",
-                "category": "general",
-                "control_flow": false,
-                "operands": [
-                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["X2"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64},
-                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
-                ],
-                "implicit_operands": []
-            },
-            {
-                "name": "LDR",
-                "category": "general",
-                "control_flow": false,
-                "operands": [
-                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["GPR"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64, "values": ["X2"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
-                ],
-                "implicit_operands": []
-            }
-        ]
-    },
-    {
-        "name": "spectre_v1_double_load_x3",
-        "weight": 1.0,
-        "instructions":
-        [
-            {
-                "name": "LDR",
-                "category": "general",
-                "control_flow": false,
-                "operands": [
-                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["X3"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64},
-                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
-                ],
-                "implicit_operands": []
-            },
-            {
-                "name": "LDR",
-                "category": "general",
-                "control_flow": false,
-                "operands": [
-                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["GPR"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64, "values": ["X3"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
-                ],
-                "implicit_operands": []
-            }
-        ]
-    },
-    {
-        "name": "spectre_v1_double_load_x4",
-        "weight": 1.0,
-        "instructions":
-        [
-            {
-                "name": "LDR",
-                "category": "general",
-                "control_flow": false,
-                "operands": [
-                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["X4"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64},
-                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
-                ],
-                "implicit_operands": []
-            },
-            {
-                "name": "LDR",
-                "category": "general",
-                "control_flow": false,
-                "operands": [
-                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["GPR"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64, "values": ["X4"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
-                ],
-                "implicit_operands": []
-            }
-        ]
-    },
-    {
-        "name": "spectre_v1_double_load_x5",
-        "weight": 1.0,
-        "instructions":
-        [
-            {
-                "name": "LDR",
-                "category": "general",
-                "control_flow": false,
-                "operands": [
-                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["X5"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64},
-                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
-                ],
-                "implicit_operands": []
-            },
-            {
-                "name": "LDR",
-                "category": "general",
-                "control_flow": false,
-                "operands": [
-                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["GPR"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64, "values": ["X5"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
-                ],
-                "implicit_operands": []
-            }
-        ]
-    },
-    {
-        "name": "spectre_v1_double_load_x6",
-        "weight": 1.0,
-        "instructions":
-        [
-            {
-                "name": "LDR",
-                "category": "general",
-                "control_flow": false,
-                "operands": [
-                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["X6"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64},
-                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
-                ],
-                "implicit_operands": []
-            },
-            {
-                "name": "LDR",
-                "category": "general",
-                "control_flow": false,
-                "operands": [
-                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["GPR"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64, "values": ["X6"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
-                ],
-                "implicit_operands": []
-            }
-        ]
-    },
-    {
-        "name": "reg_randomizer_add-rotate-or_x0",
-        "weight": 1.0,
+        ],
         "instructions":
         [
             {
@@ -212,9 +74,9 @@
                 "category": "general",
                 "control_flow": false,
                 "operands": [
-                    {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["W0"]},
-                    {"dest": false, "src": true, "type_": "REG", "width": 32, "values": ["W0"]},
-                    {"dest": false, "src": true, "type_": "IMM", "values": ["[13-13]"], "width": 0}
+                    {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["REG_VICTIM"]},
+                    {"dest": false, "src": true, "type_": "REG", "width": 32, "values": ["REG_VICTIM"]},
+                    {"dest": false, "src": true, "type_": "IMM", "values": ["[13-13]"]}
                 ],
                 "implicit_operands": [
                     {"type_": "FLAGS", "width": 0, "src": false, "dest": false, "values": ["w", "", "", "w", "w", "", "", "", "w"]}
@@ -225,9 +87,9 @@
                 "category": "general",
                 "control_flow": false,
                 "operands": [
-                    {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["W0"]},
-                    {"dest": false, "src": true, "type_": "REG", "width": 32, "values": ["W0"]},
-                    {"dest": false, "src": true, "type_": "REG", "width": 32, "values": ["W0"]},
+                    {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["REG_VICTIM"]},
+                    {"dest": false, "src": true, "type_": "REG", "width": 32, "values": ["REG_VICTIM"]},
+                    {"dest": false, "src": true, "type_": "REG", "width": 32, "values": ["REG_VICTIM"]},
                     {"type_": "LITERAL", "values": ["ROR #9"]}
                 ],
                 "implicit_operands": [
@@ -237,38 +99,53 @@
         ]
     },
     {
-        "name": "triple_bitwise_or",
-        "weight": 0.75,
+        "name": "randreg_a13or9_mask16",
+        "description": "Performs the same randomization as randreg_a13or9, but additionally masks the low 16 bits of the register.",
+        "weight": 0.5,
+        "operand_aliases":
+        [
+            {
+                "name": "REG_VICTIM",
+                "operand": {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["GPR"]}
+            }
+        ],
         "instructions":
         [
             {
-                "name": "ORR", "category": "general", "control_flow": false,
+                "name": "ADD",
+                "category": "general",
+                "control_flow": false,
                 "operands": [
-                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 32, "values": ["GPR", "SP"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["bitmask"], "width": 32}
+                    {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["REG_VICTIM"]},
+                    {"dest": false, "src": true, "type_": "REG", "width": 32, "values": ["REG_VICTIM"]},
+                    {"dest": false, "src": true, "type_": "IMM", "values": ["[13-13]"]}
                 ],
                 "implicit_operands": [
                     {"type_": "FLAGS", "width": 0, "src": false, "dest": false, "values": ["w", "", "", "w", "w", "", "", "", "w"]}
                 ]
             },
             {
-                "name": "ORR", "category": "general", "control_flow": false,
+                "name": "EOR",
+                "category": "general",
+                "control_flow": false,
                 "operands": [
-                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 32, "values": ["GPR", "SP"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["bitmask"], "width": 32}
+                    {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["REG_VICTIM"]},
+                    {"dest": false, "src": true, "type_": "REG", "width": 32, "values": ["REG_VICTIM"]},
+                    {"dest": false, "src": true, "type_": "REG", "width": 32, "values": ["REG_VICTIM"]},
+                    {"type_": "LITERAL", "values": ["ROR #9"]}
                 ],
                 "implicit_operands": [
                     {"type_": "FLAGS", "width": 0, "src": false, "dest": false, "values": ["w", "", "", "w", "w", "", "", "", "w"]}
                 ]
             },
             {
-                "name": "ORR", "category": "general", "control_flow": false,
+                "name": "AND",
+                "category": "general",
+                "control_flow": false,
                 "operands": [
-                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 32, "values": ["GPR", "SP"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["bitmask"], "width": 32}
+                    {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["REG_VICTIM"]},
+                    {"dest": false, "src": true, "type_": "REG", "width": 32, "values": ["REG_VICTIM"]},
+                    {"dest": false, "src": true, "type_": "IMM", "values": ["[65535-65535]"]}
                 ],
                 "implicit_operands": [
                     {"type_": "FLAGS", "width": 0, "src": false, "dest": false, "values": ["w", "", "", "w", "w", "", "", "", "w"]}
@@ -277,53 +154,243 @@
         ]
     },
     {
-        "name": "quadruple_subtraction",
-        "weight": 0.5,
+        "name": "randreg_a13or9_mask16_cmp",
+        "description": "Performs the same pseudo-randomization and masking as randreg_a13or9, but additionally makes a comparison between the randomized register and the low-16-bits of a different register.",
+        "weight": 0.75,
+        "operand_aliases":
+        [
+            {
+                "name": "REG_VICTIM",
+                "operand": {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["GPR"]}
+            },
+            {
+                "name": "REG_COMPARE",
+                "operand": {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["GPR"]}
+            }
+        ],
         "instructions":
         [
             {
-                "name": "SUB", "category": "general", "control_flow": false,
+                "name": "ADD",
+                "category": "general",
+                "control_flow": false,
                 "operands": [
-                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 32, "values": ["GPR", "SP"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR", "SP"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR"]}
+                    {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["REG_VICTIM"]},
+                    {"dest": false, "src": true, "type_": "REG", "width": 32, "values": ["REG_VICTIM"]},
+                    {"dest": false, "src": true, "type_": "IMM", "values": ["[13-13]"]}
                 ],
                 "implicit_operands": [
                     {"type_": "FLAGS", "width": 0, "src": false, "dest": false, "values": ["w", "", "", "w", "w", "", "", "", "w"]}
                 ]
             },
             {
-                "name": "SUB", "category": "general", "control_flow": false,
+                "name": "EOR",
+                "category": "general",
+                "control_flow": false,
                 "operands": [
-                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 32, "values": ["GPR", "SP"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR", "SP"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR"]}
+                    {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["REG_VICTIM"]},
+                    {"dest": false, "src": true, "type_": "REG", "width": 32, "values": ["REG_VICTIM"]},
+                    {"dest": false, "src": true, "type_": "REG", "width": 32, "values": ["REG_VICTIM"]},
+                    {"type_": "LITERAL", "values": ["ROR #9"]}
                 ],
                 "implicit_operands": [
                     {"type_": "FLAGS", "width": 0, "src": false, "dest": false, "values": ["w", "", "", "w", "w", "", "", "", "w"]}
                 ]
             },
             {
-                "name": "SUB", "category": "general", "control_flow": false,
+                "name": "AND",
+                "category": "general",
+                "control_flow": false,
                 "operands": [
-                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 32, "values": ["GPR", "SP"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR", "SP"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR"]}
+                    {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["REG_VICTIM"]},
+                    {"dest": false, "src": true, "type_": "REG", "width": 32, "values": ["REG_VICTIM"]},
+                    {"dest": false, "src": true, "type_": "IMM", "values": ["[65535-65535]"]}
                 ],
                 "implicit_operands": [
                     {"type_": "FLAGS", "width": 0, "src": false, "dest": false, "values": ["w", "", "", "w", "w", "", "", "", "w"]}
                 ]
             },
             {
-                "name": "SUB", "category": "general", "control_flow": false,
+                "name": "AND",
+                "category": "general",
+                "control_flow": false,
                 "operands": [
-                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 32, "values": ["GPR", "SP"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR", "SP"]},
-                    {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR"]}
+                    {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["REG_COMPARE"]},
+                    {"dest": false, "src": true, "type_": "REG", "width": 32, "values": ["REG_COMPARE"]},
+                    {"dest": false, "src": true, "type_": "IMM", "values": ["[65535-65535]"]}
                 ],
                 "implicit_operands": [
                     {"type_": "FLAGS", "width": 0, "src": false, "dest": false, "values": ["w", "", "", "w", "w", "", "", "", "w"]}
                 ]
+            },
+            {
+                "name": "CMP",
+                "category": "general",
+                "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["REG_VICTIM"]},
+                    {"dest": false, "src": true, "type_": "REG", "width": 32, "values": ["REG_COMPARE"]}
+                ],
+                "implicit_operands": [
+                    {"type_": "FLAGS", "width": 0, "src": false, "dest": false, "values": ["w", "", "", "w", "w", "", "", "", "w"]}
+                ]
+            }
+        ]
+    },
+    {
+        "name": "data_dependent_double_load",
+        "description": "Performs two consecutive load instructions, with the result of the first load used as the address for the second load. (Spectre v1)",
+        "weight": 0.6,
+        "operand_aliases":
+        [
+            {
+                "name": "REG_A",
+                "operand": {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["GPR"]}
+            },
+            {
+                "name": "REG_B",
+                "operand": {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["GPR"]}
+            },
+            {
+                "name": "REG_C",
+                "operand": {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["GPR"]}
+            }
+        ],
+        "instructions":
+        [
+            {
+                "name": "LDR",
+                "category": "general",
+                "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "type_": "REG", "width": 64, "values": ["REG_A"]},
+                    {"dest": false, "src": true, "type_": "MEM", "width": 64, "values": ["REG_C"]},
+                    {"dest": false, "src": true, "type_": "IMM", "values": ["[-256-255]"]}
+                ],
+                "implicit_operands": []
+            },
+            {
+                "name": "LDR",
+                "category": "general",
+                "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "type_": "REG", "width": 64, "values": ["REG_B"]},
+                    {"dest": false, "src": true, "type_": "MEM", "width": 64, "values": ["REG_A"]},
+                    {"dest": false, "src": true, "type_": "IMM", "values": ["[-256-255]"]}
+                ],
+                "implicit_operands": []
+            }
+        ]
+    },
+    {
+        "name": "data_dependent_double_load_shift64",
+        "description": "Performs the same two loads as data_dependent_double_load, but inserts a 64-bit left-shift of the first load's result in between the two loads. (Cache line alignment)",
+        "weight": 0.75,
+        "operand_aliases":
+        [
+            {
+                "name": "REG_A",
+                "operand": {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["GPR"]}
+            },
+            {
+                "name": "REG_B",
+                "operand": {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["GPR"]}
+            },
+            {
+                "name": "REG_C",
+                "operand": {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["GPR"]}
+            }
+        ],
+        "instructions":
+        [
+            {
+                "name": "LDR",
+                "category": "general",
+                "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "type_": "REG", "width": 64, "values": ["REG_A"]},
+                    {"dest": false, "src": true, "type_": "MEM", "width": 64, "values": ["REG_C"]},
+                    {"dest": false, "src": true, "type_": "IMM", "values": ["[-256-255]"]}
+                ],
+                "implicit_operands": []
+            },
+            {
+                "name": "LSL",
+                "category": "general",
+                "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["REG_A"]},
+                    {"dest": false, "src": true, "type_": "REG", "width": 32, "values": ["REG_A"]},
+                    {"dest": false, "src": true, "type_": "IMM", "values": ["[6-6]"]}
+                ],
+                "implicit_operands": []
+            },
+            {
+                "name": "LDR",
+                "category": "general",
+                "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "type_": "REG", "width": 64, "values": ["REG_B"]},
+                    {"dest": false, "src": true, "type_": "MEM", "width": 64, "values": ["REG_A"]},
+                    {"dest": false, "src": true, "type_": "IMM", "values": ["[-256-255]"]}
+                ],
+                "implicit_operands": []
+            }
+        ]
+    },
+    {
+        "name": "data_dependent_chain_multiplication_3",
+        "description": "A chain of three multiplication instructions, each with a data dependency on the previous instruction.",
+        "weight": 0.75,
+        "operand_aliases":
+        [
+            {
+                "name": "REG_A",
+                "operand": {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["GPR"]}
+            },
+            {
+                "name": "REG_B",
+                "operand": {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["GPR"]}
+            },
+            {
+                "name": "REG_C",
+                "operand": {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["GPR"]}
+            }
+        ],
+        "instructions":
+        [
+            {
+                "name": "MUL",
+                "category": "general",
+                "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "type_": "REG", "width": 64, "values": ["REG_A"]},
+                    {"dest": true, "src": false, "type_": "REG", "width": 64, "values": ["REG_B"]},
+                    {"dest": true, "src": false, "type_": "REG", "width": 64, "values": ["REG_C"]}
+                ],
+                "implicit_operands": []
+            },
+            {
+                "name": "MUL",
+                "category": "general",
+                "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "type_": "REG", "width": 64, "values": ["REG_B"]},
+                    {"dest": true, "src": false, "type_": "REG", "width": 64, "values": ["REG_A"]},
+                    {"dest": true, "src": false, "type_": "REG", "width": 64, "values": ["REG_C"]}
+                ],
+                "implicit_operands": []
+            },
+            {
+                "name": "MUL",
+                "category": "general",
+                "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "type_": "REG", "width": 64, "values": ["REG_C"]},
+                    {"dest": true, "src": false, "type_": "REG", "width": 64, "values": ["REG_A"]},
+                    {"dest": true, "src": false, "type_": "REG", "width": 64, "values": ["REG_B"]}
+                ],
+                "implicit_operands": []
             }
         ]
     }

--- a/src/arm64/tests/example_gadgets.json
+++ b/src/arm64/tests/example_gadgets.json
@@ -1,0 +1,297 @@
+[
+    {
+        "name": "spectre_v1_double_load_x0",
+        "weight": 1.0,
+        "instructions":
+        [
+            {
+                "name": "LDR",
+                "category": "general",
+                "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["X0"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64},
+                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
+                ],
+                "implicit_operands": []
+            },
+            {
+                "name": "LDR",
+                "category": "general",
+                "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["GPR"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64, "values": ["X0"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
+                ],
+                "implicit_operands": []
+            }
+        ]
+    },
+    {
+        "name": "spectre_v1_double_load_x1",
+        "weight": 1.0,
+        "instructions":
+        [
+            {
+                "name": "LDR",
+                "category": "general",
+                "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["X1"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64},
+                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
+                ],
+                "implicit_operands": []
+            },
+            {
+                "name": "LDR",
+                "category": "general",
+                "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["GPR"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64, "values": ["X1"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
+                ],
+                "implicit_operands": []
+            }
+        ]
+    },
+    {
+        "name": "spectre_v1_double_load_x2",
+        "weight": 1.0,
+        "instructions":
+        [
+            {
+                "name": "LDR",
+                "category": "general",
+                "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["X2"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64},
+                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
+                ],
+                "implicit_operands": []
+            },
+            {
+                "name": "LDR",
+                "category": "general",
+                "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["GPR"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64, "values": ["X2"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
+                ],
+                "implicit_operands": []
+            }
+        ]
+    },
+    {
+        "name": "spectre_v1_double_load_x3",
+        "weight": 1.0,
+        "instructions":
+        [
+            {
+                "name": "LDR",
+                "category": "general",
+                "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["X3"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64},
+                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
+                ],
+                "implicit_operands": []
+            },
+            {
+                "name": "LDR",
+                "category": "general",
+                "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["GPR"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64, "values": ["X3"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
+                ],
+                "implicit_operands": []
+            }
+        ]
+    },
+    {
+        "name": "spectre_v1_double_load_x4",
+        "weight": 1.0,
+        "instructions":
+        [
+            {
+                "name": "LDR",
+                "category": "general",
+                "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["X4"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64},
+                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
+                ],
+                "implicit_operands": []
+            },
+            {
+                "name": "LDR",
+                "category": "general",
+                "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["GPR"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64, "values": ["X4"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
+                ],
+                "implicit_operands": []
+            }
+        ]
+    },
+    {
+        "name": "spectre_v1_double_load_x5",
+        "weight": 1.0,
+        "instructions":
+        [
+            {
+                "name": "LDR",
+                "category": "general",
+                "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["X5"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64},
+                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
+                ],
+                "implicit_operands": []
+            },
+            {
+                "name": "LDR",
+                "category": "general",
+                "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["GPR"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64, "values": ["X5"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
+                ],
+                "implicit_operands": []
+            }
+        ]
+    },
+    {
+        "name": "spectre_v1_double_load_x6",
+        "weight": 1.0,
+        "instructions":
+        [
+            {
+                "name": "LDR",
+                "category": "general",
+                "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["X6"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64},
+                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
+                ],
+                "implicit_operands": []
+            },
+            {
+                "name": "LDR",
+                "category": "general",
+                "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 64, "values": ["GPR"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "MEM", "width": 64, "values": ["X6"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["[-256-255]"], "width": 0}
+                ],
+                "implicit_operands": []
+            }
+        ]
+    },
+    {
+        "name": "triple_bitwise_or",
+        "weight": 0.75,
+        "instructions":
+        [
+            {
+                "name": "ORR", "category": "general", "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 32, "values": ["GPR", "SP"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["bitmask"], "width": 32}
+                ],
+                "implicit_operands": [
+                    {"type_": "FLAGS", "width": 0, "src": false, "dest": false, "values": ["w", "", "", "w", "w", "", "", "", "w"]}
+                ]
+            },
+            {
+                "name": "ORR", "category": "general", "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 32, "values": ["GPR", "SP"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["bitmask"], "width": 32}
+                ],
+                "implicit_operands": [
+                    {"type_": "FLAGS", "width": 0, "src": false, "dest": false, "values": ["w", "", "", "w", "w", "", "", "", "w"]}
+                ]
+            },
+            {
+                "name": "ORR", "category": "general", "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 32, "values": ["GPR", "SP"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "IMM", "values": ["bitmask"], "width": 32}
+                ],
+                "implicit_operands": [
+                    {"type_": "FLAGS", "width": 0, "src": false, "dest": false, "values": ["w", "", "", "w", "w", "", "", "", "w"]}
+                ]
+            }
+        ]
+    },
+    {
+        "name": "quadruple_subtraction",
+        "weight": 0.5,
+        "instructions":
+        [
+            {
+                "name": "SUB", "category": "general", "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 32, "values": ["GPR", "SP"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR", "SP"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR"]}
+                ],
+                "implicit_operands": [
+                    {"type_": "FLAGS", "width": 0, "src": false, "dest": false, "values": ["w", "", "", "w", "w", "", "", "", "w"]}
+                ]
+            },
+            {
+                "name": "SUB", "category": "general", "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 32, "values": ["GPR", "SP"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR", "SP"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR"]}
+                ],
+                "implicit_operands": [
+                    {"type_": "FLAGS", "width": 0, "src": false, "dest": false, "values": ["w", "", "", "w", "w", "", "", "", "w"]}
+                ]
+            },
+            {
+                "name": "SUB", "category": "general", "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 32, "values": ["GPR", "SP"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR", "SP"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR"]}
+                ],
+                "implicit_operands": [
+                    {"type_": "FLAGS", "width": 0, "src": false, "dest": false, "values": ["w", "", "", "w", "w", "", "", "", "w"]}
+                ]
+            },
+            {
+                "name": "SUB", "category": "general", "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 32, "values": ["GPR", "SP"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR", "SP"]},
+                    {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR"]}
+                ],
+                "implicit_operands": [
+                    {"type_": "FLAGS", "width": 0, "src": false, "dest": false, "values": ["w", "", "", "w", "w", "", "", "", "w"]}
+                ]
+            }
+        ]
+    }
+]
+

--- a/src/arm64/tests/example_gadgets.json
+++ b/src/arm64/tests/example_gadgets.json
@@ -203,6 +203,40 @@
         ]
     },
     {
+        "name": "reg_randomizer_add-rotate-or_x0",
+        "weight": 1.0,
+        "instructions":
+        [
+            {
+                "name": "ADD",
+                "category": "general",
+                "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["W0"]},
+                    {"dest": false, "src": true, "type_": "REG", "width": 32, "values": ["W0"]},
+                    {"dest": false, "src": true, "type_": "IMM", "values": ["[13-13]"], "width": 0}
+                ],
+                "implicit_operands": [
+                    {"type_": "FLAGS", "width": 0, "src": false, "dest": false, "values": ["w", "", "", "w", "w", "", "", "", "w"]}
+                ]
+            },
+            {
+                "name": "EOR",
+                "category": "general",
+                "control_flow": false,
+                "operands": [
+                    {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["W0"]},
+                    {"dest": false, "src": true, "type_": "REG", "width": 32, "values": ["W0"]},
+                    {"dest": false, "src": true, "type_": "REG", "width": 32, "values": ["W0"]},
+                    {"type_": "LITERAL", "values": ["ROR #9"]}
+                ],
+                "implicit_operands": [
+                    {"type_": "FLAGS", "width": 0, "src": false, "dest": false, "values": ["w", "", "", "w", "w", "", "", "", "w"]}
+                ]
+            }
+        ]
+    },
+    {
         "name": "triple_bitwise_or",
         "weight": 0.75,
         "instructions":

--- a/src/arm64/tests/test-gadgets.yaml
+++ b/src/arm64/tests/test-gadgets.yaml
@@ -1,0 +1,25 @@
+instruction_set: arm64
+instruction_categories:
+  - general
+contract_observation_clause: l1d
+
+program_size: 32
+min_bb_per_function: 4
+max_bb_per_function: 6
+avg_mem_accesses: 8
+input_gen_entropy_bits: 9
+
+enable_ssbp_patch: true
+enable_faulty_page: false
+
+logging_modes:
+  - dbg_generator
+  - dbg_generator_gadgets
+  - dbg_input_gen
+
+executor_repetitions: 1
+
+gadget_file: /path/to/sca-fuzzer/src/arm64/tests/example_gadgets.json
+avg_gadgets_per_bb: 0.5
+max_gadgets_per_bb: 2
+

--- a/src/config.py
+++ b/src/config.py
@@ -60,9 +60,12 @@ class ConfCls:
     register_blocklist: List[str] = []
     """ register_blocklist: list of registers that will NOT be used for generating programs """
     gadget_file: str = ""
-    """ JSON file defining ordered assembly gadgets (in the same format as InstructionSpecs) """
-    gadget_chance: float = 0.05
-    """ Percent chance (out of 1.0) to place a random gadget instead of a random instruction during generation. """
+    """ gadget_file: JSON file defining ordered assembly gadgets (in the same format as InstructionSpecs) """
+    avg_gadgets_per_bb: float = 0.5
+    """ avg_gadgets_per_bb: average number of gadgets placed in each basic block of generated
+        programs (can be a non-integer value)"""
+    max_gadgets_per_bb: int = 2
+    """ max_gadgets_per_bb: maximum number of gadgets allowed to be placed into a single basic block """
     avoid_data_dependencies: bool = False
     """ [DEPRECATED] avoid_data_dependencies: """
     generate_memory_accesses_in_pairs: bool = False

--- a/src/config.py
+++ b/src/config.py
@@ -60,7 +60,7 @@ class ConfCls:
     register_blocklist: List[str] = []
     """ register_blocklist: list of registers that will NOT be used for generating programs """
     gadget_file: str = ""
-    """ gadget_file: JSON file defining ordered assembly gadgets (in the same format as InstructionSpecs) """
+    """ gadget_file: JSON file defining ordered assembly gadgets"""
     avg_gadgets_per_bb: float = 0.5
     """ avg_gadgets_per_bb: average number of gadgets placed in each basic block of generated
         programs (can be a non-integer value)"""

--- a/src/config.py
+++ b/src/config.py
@@ -47,6 +47,10 @@ class ConfCls:
     """ max_bb_per_function: maximum number of basic blocks per function in generated programs """
     register_blocklist: List[str] = []
     """ register_blocklist: list of registers that will NOT be used for generating programs """
+    gadget_file: str = ""
+    """ JSON file defining ordered assembly gadgets (in the same format as InstructionSpecs) """
+    gadget_chance: int = 7
+    """ Percent chance (out of 100) to place a random gadget instead of a random instruction during generation. """
     avoid_data_dependencies: bool = False
     """ [DEPRECATED] avoid_data_dependencies: """
     generate_memory_accesses_in_pairs: bool = False

--- a/src/config.py
+++ b/src/config.py
@@ -61,7 +61,7 @@ class ConfCls:
     """ register_blocklist: list of registers that will NOT be used for generating programs """
     gadget_file: str = ""
     """ JSON file defining ordered assembly gadgets (in the same format as InstructionSpecs) """
-    gadget_chance: float = 0.03
+    gadget_chance: float = 0.05
     """ Percent chance (out of 1.0) to place a random gadget instead of a random instruction during generation. """
     avoid_data_dependencies: bool = False
     """ [DEPRECATED] avoid_data_dependencies: """

--- a/src/config.py
+++ b/src/config.py
@@ -49,8 +49,8 @@ class ConfCls:
     """ register_blocklist: list of registers that will NOT be used for generating programs """
     gadget_file: str = ""
     """ JSON file defining ordered assembly gadgets (in the same format as InstructionSpecs) """
-    gadget_chance: int = 7
-    """ Percent chance (out of 100) to place a random gadget instead of a random instruction during generation. """
+    gadget_chance: float = 0.03
+    """ Percent chance (out of 1.0) to place a random gadget instead of a random instruction during generation. """
     avoid_data_dependencies: bool = False
     """ [DEPRECATED] avoid_data_dependencies: """
     generate_memory_accesses_in_pairs: bool = False

--- a/src/generator.py
+++ b/src/generator.py
@@ -719,6 +719,11 @@ class CodeGadget():
         self.instruction_set = instructions
         self.num_mem_accesses = self.count_mem_accesses()
 
+        # forbid the use of control-flow instructions in Revizor gadgets
+        for ispec in self.instruction_set.instructions:
+            assert not ispec.control_flow, "gadgets cannot contain control-flow instructions " \
+                                           "(such as \"%s\")" % ispec.name
+
     # Computes the length of the gadget's instruction list.
     def __len__(self):
         return len(self.instruction_set.instructions)

--- a/src/generator.py
+++ b/src/generator.py
@@ -586,9 +586,8 @@ class RandomGenerator(ConfigurableGenerator, abc.ABC):
                 raise NotSupportedException()
 
     def add_instructions_in_function(self, func: Function):
-        # in this function, we evenly fill all BBs with random instructions by
-        # randomly choosing basic blocks and adding one instruction (or gadget)
-        # at a time
+        # evenly fill all BBs with random instructions by randomly choosing
+        # basic blocks and adding one instruction (or gadget) at a time
         basic_blocks_to_fill = func.get_all()[1:-1]
 
         # compute a probability of a gadget being selected, based on the average
@@ -608,7 +607,8 @@ class RandomGenerator(ConfigurableGenerator, abc.ABC):
                 gadget_counts[bb.name] = 0
 
             # decide between placing a code gadget or a random instruction
-            # (don't interrupt the placement of two memory-access instructions)
+            #  - don't interrupt the placement of two memory-access instructions
+            #  - don't exceed the maximum number of gadgets for a BB
             use_gadget = random.uniform(0, 1) < gadget_chance and \
                          not self.had_recent_memory_access and \
                          gadget_counts[bb.name] < CONF.max_gadgets_per_bb

--- a/src/interfaces.py
+++ b/src/interfaces.py
@@ -30,6 +30,7 @@ class OT(Enum):
     AGEN = 5  # memory address in LEA instructions
     FLAGS = 6
     COND = 7
+    LITERAL = 8 # literal string operand, parsed and placed exactly as specified
 
     def __str__(self):
         return str(self._name_)
@@ -162,6 +163,10 @@ class CondOperand(Operand):
 
     def __init__(self, value):
         super().__init__(value, OT.COND, True, False)
+
+class LiteralOperand(Operand):
+    def __init__(self, value):
+        super().__init__(value, OT.LITERAL, False, False)
 
 
 class InstructionSpec:

--- a/src/interfaces.py
+++ b/src/interfaces.py
@@ -192,6 +192,7 @@ class Instruction:
     implicit_operands: List[Operand]
     category: str
     control_flow = False
+    comment: str = None
 
     next: Optional[Instruction] = None
     previous: Optional[Instruction] = None
@@ -348,6 +349,13 @@ class Instruction:
                 res.append(o)
 
         return res
+
+    def set_comment(self, comment: str):
+        """
+        Sets the instruction's comment value, to be added to the end of its line
+        during printing.
+        """
+        self.comment = comment
 
 
 class BasicBlock:
@@ -719,7 +727,7 @@ class InstructionSetAbstract(ABC):
     has_writes: bool = False
 
     @abstractmethod
-    def __init__(self, filename: str, include_categories=None):
+    def __init__(self, filename=None, include_categories=None):
         pass
 
 

--- a/src/isa_loader.py
+++ b/src/isa_loader.py
@@ -19,6 +19,7 @@ class InstructionSet(InstructionSetAbstract):
         "AGEN": OT.AGEN,
         "FLAGS": OT.FLAGS,
         "COND": OT.COND,
+        "LITERAL": OT.LITERAL
     }
 
     def __init__(self, filename=None, include_categories=None):
@@ -60,8 +61,14 @@ class InstructionSet(InstructionSetAbstract):
         op_values = op.get("values", [])
         if op_type == "REG":
             op_values = sorted(op_values)
-        spec = OperandSpec(op_values, op_type, op["src"], op["dest"])
-        spec.width = op["width"]
+
+        # assume defaults for some fields if none are specified
+        is_src = False if "src" not in op else op["src"]
+        is_dest = False if "dest" not in op else op["dest"]
+        width = 0 if "width" not in op else op["width"]
+
+        spec = OperandSpec(op_values, op_type, is_src, is_dest)
+        spec.width = width
 
         if op_type == OT.MEM:
             parent.has_mem_operand = True

--- a/src/isa_loader.py
+++ b/src/isa_loader.py
@@ -21,17 +21,17 @@ class InstructionSet(InstructionSetAbstract):
         "COND": OT.COND,
     }
 
-    def __init__(self, filename: str, include_categories=None):
+    def __init__(self, filename=None, include_categories=None):
         self.instructions = []
-        self.init_from_file(filename)
-        self.reduce(include_categories)
-        self.dedup()
+        if filename is not None:
+            self.init_from_file(filename)
+            self.reduce(include_categories)
+            self.dedup()
         super().__init__(filename, include_categories)
-
-    def init_from_file(self, filename: str):
-        with open(filename, "r") as f:
-            root = json.load(f)
-        for instruction_node in root:
+    
+    # Initializes the InstructionSet from a parsed JSON dictionary.
+    def init_from_list(self, data: list):
+        for instruction_node in data:
             instruction = InstructionSpec()
             instruction.name = instruction_node["name"]
             instruction.category = instruction_node["category"]
@@ -48,7 +48,13 @@ class InstructionSet(InstructionSetAbstract):
                 instruction.implicit_operands.append(op)
 
             self.instructions.append(instruction)
-
+ 
+    # Initializes the InstructionSet from a given file.
+    def init_from_file(self, filename: str):
+        with open(filename, "r") as f:
+            root = json.load(f)
+        self.init_from_list(root)
+        
     def parse_operand(self, op: Dict, parent: InstructionSpec) -> OperandSpec:
         op_type = self.ot_str_to_enum[op["type_"]]
         op_values = op.get("values", [])

--- a/src/service.py
+++ b/src/service.py
@@ -106,6 +106,7 @@ class Logger:
     dbg_model: bool = False
     dbg_coverage: bool = False
     dbg_generator: bool = False
+    dbg_generator_gadgets: bool = False
     dbg_input_gen: bool = False
 
     def __init__(self) -> None:
@@ -122,7 +123,7 @@ class Logger:
         if not __debug__:
             if self.dbg_timestamp or self.dbg_model or self.dbg_coverage or \
                self.dbg_traces or self.dbg_violation or self.dbg_generator or \
-               self.dbg_input_gen:
+               self.dbg_generator_gadgets or self.dbg_input_gen:
                 self.warning(
                     "", "Current value of `logging_modes` requires debugging mode!\n"
                     "Remove '-O' from python arguments")
@@ -299,6 +300,18 @@ class Logger:
         # if an output path was set in the input, include it in the message
         if len(out_path) > 0:
             msg += " at %s" % out_path
+        print(msg)
+
+    def fuzzer_report_gadget_placement(self, gadget, bb):
+        """
+        If 'dbg_generator_gadgets' is set, this reports when gadgets are
+        selected and placed into a generated program.
+        """
+        if not self.dbg_generator_gadgets:
+            return
+
+        msg = "Placed gadget \"%s\" (%d instructions) into \"%s\"." % \
+              (gadget.name, len(gadget), bb.name)
         print(msg)
 
     # ==============================================================================================

--- a/src/x86/x86_generator.py
+++ b/src/x86/x86_generator.py
@@ -647,7 +647,9 @@ class X86Printer(Printer):
 
     def instruction_to_str(self, inst: Instruction):
         operands = ", ".join([self.operand_to_str(op) for op in inst.operands])
-        comment = "# instrumentation" if inst.is_instrumentation else ""
+        if inst.is_instrumentation:
+            inst.set_comment("instrumentation")
+        comment = ("# %s" % inst.comment) if inst.comment is not None else ""
         return f"{inst.name} {operands} {comment}"
 
     def operand_to_str(self, op: Operand) -> str:


### PR DESCRIPTION
This PR implements the concept of **gadgets** into Revizor's program generator. Here, a **gadget** refers to a small list of assembly instructions placed in a specific order for a specific reason. I've made this PR description somewhat lengthy to make sure I document my thought process in implementing this feature.

## Benefits of Gadgets

Considering Spectre v1, the below gadget (in pseudocode), which features two memory load instructions, would be useful for causing an extra line in the CPU cache to be allocated during speculative execution.

```python
LOAD REG1, [REG2] # REG1 is destination, REG2 is source address
LOAD REG3, [REG1] # REG1's result from previous load is used as the next load's address
```

Or consider another gadget, potentially useful for increasing the CPU's speculative execution window by creating a chain of data-dependent instructions:

```python
MUL REG1, REG2, REG3
MUL REG4, REG1, REG3 # depends on REG1
MUL REG2, REG4, REG3 # depends on REG4
MUL REG3, REG2, REG1 # depends on REG2
# ...
```

Because Revizor's program generator randomly places assembly instructions, specific assembly sequences like these won't easily be generated. Gadgets make this possible.

## Gadget File

At runtime, the user can specify the path to a gadget file through a config field (`gadget_file`). This file is formatted in JSON and uses the same syntax for specifying assembly instructions as Revizor's ISA specification parser. Within this file, the user can place interesting assembly gadgets he/she wants to see in Revizor's generated programs. Each gadget has a name and an optional weight (used to tune how often gadgets appear in generated programs). Here's an example of what one gadget might look like:

```json
{
    "name": "double_subtraction",
    "description": "Two consecutive subtraction instructions.",
    "weight": 0.5,
    "instructions":
    [
        {
            "name": "SUB", "category": "general", "control_flow": false,
            "operands": [
                {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 32, "values": ["GPR", "SP"]},
                {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR", "SP"]},
                {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR"]}
            ],
            "implicit_operands": [
                {"type_": "FLAGS", "width": 0, "src": false, "dest": false, "values": ["w", "", "", "w", "w", "", "", "", "w"]}
            ]
        },
        {
            "name": "SUB", "category": "general", "control_flow": false,
            "operands": [
                {"dest": true, "src": false, "comment": "", "type_": "REG", "width": 32, "values": ["GPR", "SP"]},
                {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR", "SP"]},
                {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR"]}
            ],
            "implicit_operands": [
                {"type_": "FLAGS", "width": 0, "src": false, "dest": false, "values": ["w", "", "", "w", "w", "", "", "", "w"]}
            ]
        }
    ]
}
```

If the generator chooses to place this particular gadget into a program, two randomized `SUB` instructions will be placed (consecutively) within a basic block.

(I've created an example gadget file at [`src/arm64/tests/example_gadgets.json`](https://github.com/microsoft/sca-fuzzer/blob/generator-gadgets/src/arm64/tests/example_gadgets.json)).

## Gadget Selection

As the program generator fills basic blocks with instructions, it may choose to instead select a random gadget from the gadget file and place it into the program. This pseudocode describes the basic idea of how it decides:

```
while (program isn't full yet)
{
    bb = choose_random_basic_block();
    if (random_chance_to_use_gadget())
    {
        gadget = select_random_gadget_that_fits();
        bb.insert(gadget.instructions);
    }
    else
    {
        instruction = generate_random_instruction();
        bb.insert(instruction);
    }
}
```

The randomness of gadget placement is configurable using a few new config fields:

* `CONF.avg_gadgets_per_bb` dictates, roughly, how many gadgets are selected and placed into each basic block of the test case.
* `CONF.max_gadgets_per_bb` forces a maximum number of gadgets that can be placed into each basic block.

Gadget placement will also _not_ occur if:

* A gadget is too big (i.e. won't fit in `CONF.program_size`)
* The generator is in the middle of placing two memory access instructions
* A gadget would exceed the average number of memory accesses (`CONF.avg_mem_accesses`)

## Operand Aliasing

I've also given gadgets the ability to specify unique operand aliases, to control how instruction operands (such as registers) are used within the same gadget. Defining an operand alias (let's say it's named `REG_A`) as a GPR operand allows us to specify `REG_A` in the operands of the gadget's instructions. When the gadgets is placed into the code, all instances of `REG_A` will be replaced by the same randomly-chosen register.

See this gadget as an example:

```json
{
    "name": "spectre_double_load",
    "description": "Two consecutive load instructions in a spectre-like style (with the first load result used as the second load's address)..",
    "weight": 0.75,
    "operand_aliases":
    [
        {
            "name": "REG_A",
            "operand": {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR"]}
        },
        {
            "name": "REG_B",
            "operand": {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR"]}
        },
        {
            "name": "REG_B",
            "operand": {"dest": false, "src": true, "comment": "", "type_": "REG", "width": 32, "values": ["GPR"]}
        }
    ],
    "instructions":
    [
        {
            "name": "LDR",
            "category": "general",
            "control_flow": false,
            "operands": [
                {"dest": true, "src": false, "type_": "REG", "width": 64, "values": ["REG_A"]},
                {"dest": false, "src": true, "type_": "MEM", "width": 64, "values": ["REG_C"]},
                {"dest": false, "src": true, "type_": "IMM", "values": ["[-256-255]"]}
            ],
            "implicit_operands": []
        },
        {
            "name": "LDR",
            "category": "general",
            "control_flow": false,
            "operands": [
                {"dest": true, "src": false, "type_": "REG", "width": 64, "values": ["REG_B"]},
                {"dest": false, "src": true, "type_": "MEM", "width": 64, "values": ["REG_A"]},
                {"dest": false, "src": true, "type_": "IMM", "values": ["[-256-255]"]}
            ],
            "implicit_operands": []
        }
    ]
}
```

The `operand_aliases` allow this gadget to use random registers to fill in `REG_A`, `REG_B`, and `REG_C`, but keep their values consistent across all uses in each of the two load instructions.

## Other Additions

### Literal Operand

To support extra operands that may not fit under the existing types, I've implemented a `LiteralOperand`, which allows for any arbitrary literal string to be used as an operand for an assembly instruction. Take this `EOR` instruction specification as an example:

```json
{
    "name": "EOR",
    "category": "general",
    "control_flow": false,
    "operands": [
        {"dest": true, "src": false, "type_": "REG", "width": 32, "values": ["W0"]},
        {"dest": false, "src": true, "type_": "REG", "width": 32, "values": ["W0"]},
        {"dest": false, "src": true, "type_": "REG", "width": 32, "values": ["W0"]},
        {"type_": "LITERAL", "values": ["ROR #9"]}
    ],
    "implicit_operands": [
        {"type_": "FLAGS", "width": 0, "src": false, "dest": false, "values": ["w", "", "", "w", "w", "", "", "", "w"]}
    ]
}
```

The final operand is a `"LITERAL"`, and contains the value `"ROR #9"`. This type of operand will be placed in the assembly code as-is. In this example, it allows the `EOR` instruction to have a right-rotate barrel-shift operand:

```
EOR W0, W0, W0, ROR #9
```