### PR TITLE
Fix GP noncanonical contract

### DIFF
--- a/src/interfaces.py
+++ b/src/interfaces.py
@@ -76,6 +76,11 @@ class Operand(ABC):
     def get_width(self) -> int:
         return self.width
 
+    def __deecopy__(self):
+        copy = Operand(self.value[:], self.type, self.src, self.dest)
+        copy.width = self.width
+        copy.magic_value = self.magic_value
+
 
 class RegisterOperand(Operand):
 

--- a/src/interfaces.py
+++ b/src/interfaces.py
@@ -76,11 +76,6 @@ class Operand(ABC):
     def get_width(self) -> int:
         return self.width
 
-    def __deecopy__(self):
-        copy = Operand(self.value[:], self.type, self.src, self.dest)
-        copy.width = self.width
-        copy.magic_value = self.magic_value
-
 
 class RegisterOperand(Operand):
 

--- a/src/x86/x86_generator.py
+++ b/src/x86/x86_generator.py
@@ -324,18 +324,20 @@ class X86NonCanonicalAddressPass(Pass):
                         assert len(mem_operands) == 1, f"Unexpected instruction format {instr.name}"
                         mem_operand: Operand = mem_operands[0]
                         registers = mem_operand.value
-
+                        
                         offsets = ["RCX", "RDX"]
                         masks = ["RAX", "RBX"]
                         offset_reg = offsets[0]
                         mask_reg = masks[0]
-                        for reg in src_operands:
-                            if X86TargetDesc.gpr_normalized[offset_reg] == \
-                               X86TargetDesc.gpr_normalized[reg.value]:
-                                offset_reg = offsets[1]
-                            if X86TargetDesc.gpr_normalized[mask_reg] == \
-                               X86TargetDesc.gpr_normalized[reg.value]:
-                                mask_reg = masks[1]
+                        for operands in src_operands:
+                            offset_regs = re.split(r'\+|-|\*| ', operands.value)
+                            for reg in offset_regs:
+                                if X86TargetDesc.gpr_normalized[offset_reg] == \
+                                X86TargetDesc.gpr_normalized[reg]:
+                                    offset_reg = offsets[1]
+                                if X86TargetDesc.gpr_normalized[mask_reg] == \
+                                X86TargetDesc.gpr_normalized[reg]:
+                                    mask_reg = masks[1]
 
                         mask = hex((random.getrandbits(16) << 48))
                         lea = Instruction("LEA", True) \

--- a/src/x86/x86_generator.py
+++ b/src/x86/x86_generator.py
@@ -332,7 +332,7 @@ class X86NonCanonicalAddressPass(Pass):
 
                         masks_list = ["RAX", "RBX"]
                         mask_reg = masks_list[0]
-                        # Do not overwritmasks_liste offset register with mask
+                        # Do not overwrite offset register with mask
                         for operands in src_operands:
                             op_regs = re.split(r'\+|-|\*| ', operands.value)
                             for reg in op_regs:

--- a/src/x86/x86_generator.py
+++ b/src/x86/x86_generator.py
@@ -338,11 +338,11 @@ class X86NonCanonicalAddressPass(Pass):
                         offsetList = ["RCX", "RDX"]
                         offset_reg = offsetList[0]
                         # Do not reuse destination register
-                        for dest in instr.get_dest_operands():
-                            if not isinstance(dest, RegisterOperand):
+                        for op in instr.get_all_operands():
+                            if not isinstance(op, RegisterOperand):
                                 continue
                             if X86TargetDesc.gpr_normalized[offset_reg] == \
-                                X86TargetDesc.gpr_normalized[dest.value]:
+                                X86TargetDesc.gpr_normalized[op.value]:
                                 offset_reg = offsetList[1]
 
                         mask = hex((random.getrandbits(16) << 48))

--- a/src/x86/x86_generator.py
+++ b/src/x86/x86_generator.py
@@ -306,6 +306,9 @@ class X86NonCanonicalAddressPass(Pass):
                 for instr in bb:
                     if instr.is_instrumentation:
                         continue
+                    if instr.name in ["DIV", "IDIV"]:
+                    # Instrumentation is difficult to combine
+                        continue
                     if instr.has_mem_operand(True):
                         memory_instructions.append(instr)
 

--- a/src/x86/x86_generator.py
+++ b/src/x86/x86_generator.py
@@ -10,6 +10,7 @@ import re
 import random
 from typing import List, Dict, Set, Optional, Tuple
 from subprocess import run
+from copy import deepcopy
 
 from isa_loader import InstructionSet
 from interfaces import TestCase, Operand, RegisterOperand, FlagsOperand, MemoryOperand, \
@@ -486,7 +487,7 @@ class X86SandboxPass(Pass):
         The second corner case is 8-bit division, when the divisor is the AX register alone.
         Here the instrumentation become too complicated, and we simply set AX to 1.
         """
-        divisor = inst.operands[0]
+        divisor = deepcopy(inst.operands[0])
 
         # TODO: remove me - avoids a certain violation
         if divisor.width == 64 and CONF.x86_disable_div64:  # type: ignore
@@ -756,7 +757,7 @@ class X86PatchUndefinedResultPass(Pass):
         Bit Scan instructions give an undefined result when the source operand is zero.
         To avoid it, set the most significant bit.
         """
-        source = inst.operands[1]
+        source = deepcopy(inst.operands[1])
         mask = bin(1 << (source.width - 1))
         mask_size = source.width
         if source.width in [64, 32]:

--- a/src/x86/x86_generator.py
+++ b/src/x86/x86_generator.py
@@ -303,6 +303,8 @@ class X86NonCanonicalAddressPass(Pass):
 
                 memory_instructions = []
                 for instr in bb:
+                    if instr.is_instrumentation:
+                        continue
                     if instr.has_mem_operand(True):
                         memory_instructions.append(instr)
 

--- a/src/x86/x86_generator.py
+++ b/src/x86/x86_generator.py
@@ -88,8 +88,8 @@ class X86Generator(ConfigurableGenerator, abc.ABC):
         self.passes = [
             X86SandboxPass(self.target_desc),
             X86PatchUndefinedFlagsPass(self.instruction_set, self),
-            X86NonCanonicalAddressPass(),
             X86PatchUndefinedResultPass(),
+            X86NonCanonicalAddressPass(),
             X86PatchOpcodesPass(),
         ]
         self.printer = X86Printer()

--- a/src/x86/x86_generator.py
+++ b/src/x86/x86_generator.py
@@ -307,7 +307,7 @@ class X86NonCanonicalAddressPass(Pass):
                     if instr.is_instrumentation:
                         continue
                     if instr.name in ["DIV", "IDIV"]:
-                    # Instrumentation is difficult to combine
+                        # Instrumentation is difficult to combine
                         continue
                     if instr.has_mem_operand(True):
                         memory_instructions.append(instr)
@@ -330,26 +330,26 @@ class X86NonCanonicalAddressPass(Pass):
                         assert len(mem_operands) == 1, f"Unexpected instruction format {instr.name}"
                         mem_operand: Operand = mem_operands[0]
                         registers = mem_operand.value
-                        
-                        masksList = ["RAX", "RBX"]
-                        mask_reg = masksList[0]
-                        # Do not overwrite offset register with mask
-                        for operands in src_operands:
-                            usedRegs = re.split(r'\+|-|\*| ', operands.value)
-                            for reg in usedRegs:
-                                if X86TargetDesc.gpr_normalized[mask_reg] == \
-                                    X86TargetDesc.gpr_normalized[reg]:
-                                    mask_reg = masksList[1]
 
-                        offsetList = ["RCX", "RDX"]
-                        offset_reg = offsetList[0]
+                        masks_list = ["RAX", "RBX"]
+                        mask_reg = masks_list[0]
+                        # Do not overwritmasks_liste offset register with mask
+                        for operands in src_operands:
+                            op_regs = re.split(r'\+|-|\*| ', operands.value)
+                            for reg in op_regs:
+                                if X86TargetDesc.gpr_normalized[mask_reg] == \
+                                   X86TargetDesc.gpr_normalized[reg]:
+                                    mask_reg = masks_list[1]
+
+                        offset_list = ["RCX", "RDX"]
+                        offset_reg = offset_list[0]
                         # Do not reuse destination register
                         for op in instr.get_all_operands():
                             if not isinstance(op, RegisterOperand):
                                 continue
                             if X86TargetDesc.gpr_normalized[offset_reg] == \
-                                X86TargetDesc.gpr_normalized[op.value]:
-                                offset_reg = offsetList[1]
+                               X86TargetDesc.gpr_normalized[op.value]:
+                                offset_reg = offset_list[1]
 
                         mask = hex((random.getrandbits(16) << 48))
                         lea = Instruction("LEA", True) \

--- a/src/x86/x86_model.py
+++ b/src/x86/x86_model.py
@@ -893,7 +893,7 @@ class X86NonCanonicalAddress(X86FaultModelAbstract):
     """
      Load from non-canonical addresss
     """
-    last_faulty_addr: int
+    fauty_instruction_addr: int
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -904,14 +904,14 @@ class X86NonCanonicalAddress(X86FaultModelAbstract):
             return 0
 
         self.checkpoint(self.emulator, self.code_end)
-        self.last_faulty_addr = self.curr_instruction_addr
+        self.fauty_instruction_addr = self.curr_instruction_addr
         return self.curr_instruction_addr
 
     @staticmethod
     def speculate_instruction(emulator: Uc, address, size, model) -> None:
         assert isinstance(model, X86NonCanonicalAddress)
 
-        if not model.in_speculation or model.last_faulty_addr != address:
+        if not model.in_speculation or model.fauty_instruction_addr != address:
             return
 
         for mem_op in model.current_instruction.get_mem_operands():
@@ -931,8 +931,9 @@ class X86NonCanonicalAddress(X86FaultModelAbstract):
         return
 
     def reset_model(self):
-        self.last_faulty_addr = -1
+        self.fauty_instruction_addr = -1
         return super().reset_model()
+
 
 # ==================================================================================================
 # Taint tracker

--- a/src/x86/x86_model.py
+++ b/src/x86/x86_model.py
@@ -894,12 +894,12 @@ class X86NonCanonicalAddress(X86FaultModelAbstract):
      Load from non-canonical addresss
     """
     fauty_instruction_addr: int
-    address_register : int
-    register_value: int    
+    address_register: int
+    register_value: int
 
     def __init__(self, *args):
         super().__init__(*args)
-        self.relevant_faults.update([6,7])
+        self.relevant_faults.update([6, 7])
 
     def speculate_fault(self, errno: int) -> int:
         if not self.fault_triggers_speculation(errno):
@@ -923,21 +923,21 @@ class X86NonCanonicalAddress(X86FaultModelAbstract):
 
         if model.fauty_instruction_addr != address:
             return
-        
-        ## Fix non-canonical address
+
+        # Fix non-canonical address
         for mem_op in model.current_instruction.get_mem_operands():
             registers = re.split(r'\+|-|\*| ', mem_op.value)
             if len(registers) > 1:
                 continue
-            
+
             uc_reg = X86UnicornTargetDesc.reg_str_to_constant[registers[0]]
             load_address = model.emulator.reg_read(uc_reg)  # load address
-            isCanonical : bool = load_address > 0xFFFF800000000000 \
+            isCanonical: bool = load_address > 0xFFFF800000000000 \
                 or load_address < 0x00007FFFFFFFFFFF
             if not isCanonical:
-                model.address_register  = uc_reg
+                model.address_register = uc_reg
                 model.register_value = load_address
-                
+
                 if load_address & (1 << 47):  # bit 48 is 1 => high address
                     load_address = load_address | 0xFFFF800000000000
                 else:  # bit 48 is 0 => low address

--- a/src/x86/x86_model.py
+++ b/src/x86/x86_model.py
@@ -899,10 +899,6 @@ class X86NonCanonicalAddress(X86FaultModelAbstract):
         super().__init__(*args)
         self.relevant_faults.update([6, 7])
 
-    def _load_input(self, input_: Input):
-        self.last_faulty_addr = -1
-        return super()._load_input(input_)
-
     def speculate_fault(self, errno: int) -> int:
         if not self.fault_triggers_speculation(errno):
             return 0
@@ -934,6 +930,9 @@ class X86NonCanonicalAddress(X86FaultModelAbstract):
 
         return
 
+    def reset_model(self):
+        self.last_faulty_addr = -1
+        return super().reset_model()
 
 # ==================================================================================================
 # Taint tracker

--- a/src/x86/x86_model.py
+++ b/src/x86/x86_model.py
@@ -891,11 +891,11 @@ class X86FaultSkip(X86FaultModelAbstract):
 
 class X86NonCanonicalAddress(X86FaultModelAbstract):
     """
-     Load from non-canonical addresss
+     Load from non-canonical address
     """
-    fauty_instruction_addr: int
-    address_register: int
-    register_value: int
+    faulty_instruction_addr: int = -1
+    address_register: int = -1
+    register_value: int = -1
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -906,7 +906,7 @@ class X86NonCanonicalAddress(X86FaultModelAbstract):
             return 0
 
         self.checkpoint(self.emulator, self.code_end)
-        self.fauty_instruction_addr = self.curr_instruction_addr
+        self.faulty_instruction_addr = self.curr_instruction_addr
         return self.curr_instruction_addr
 
     @staticmethod
@@ -921,7 +921,7 @@ class X86NonCanonicalAddress(X86FaultModelAbstract):
             model.address_register = -1
             return
 
-        if model.fauty_instruction_addr != address:
+        if model.faulty_instruction_addr != address:
             return
 
         # Fix non-canonical address
@@ -931,10 +931,10 @@ class X86NonCanonicalAddress(X86FaultModelAbstract):
                 continue
 
             uc_reg = X86UnicornTargetDesc.reg_str_to_constant[registers[0]]
-            load_address = model.emulator.reg_read(uc_reg)  # load address
-            isCanonical: bool = load_address > 0xFFFF800000000000 \
+            load_address: int = model.emulator.reg_read(uc_reg)  # type: ignore
+            is_canonical: bool = load_address > 0xFFFF800000000000 \
                 or load_address < 0x00007FFFFFFFFFFF
-            if not isCanonical:
+            if not is_canonical:
                 model.address_register = uc_reg
                 model.register_value = load_address
 
@@ -947,7 +947,7 @@ class X86NonCanonicalAddress(X86FaultModelAbstract):
         return
 
     def reset_model(self):
-        self.fauty_instruction_addr = -1
+        self.faulty_instruction_addr = -1
         self.address_register = -1
         self.register_value = -1
         return super().reset_model()

--- a/src/x86/x86_model.py
+++ b/src/x86/x86_model.py
@@ -894,10 +894,12 @@ class X86NonCanonicalAddress(X86FaultModelAbstract):
      Load from non-canonical addresss
     """
     fauty_instruction_addr: int
+    address_register : int
+    register_value: int    
 
     def __init__(self, *args):
         super().__init__(*args)
-        self.relevant_faults.update([6, 7])
+        self.relevant_faults.update([6,7])
 
     def speculate_fault(self, errno: int) -> int:
         if not self.fault_triggers_speculation(errno):
@@ -911,27 +913,44 @@ class X86NonCanonicalAddress(X86FaultModelAbstract):
     def speculate_instruction(emulator: Uc, address, size, model) -> None:
         assert isinstance(model, X86NonCanonicalAddress)
 
-        if not model.in_speculation or model.fauty_instruction_addr != address:
+        if not model.in_speculation:
             return
 
+        if model.address_register != -1:
+            print(f"write in {model.address_register} value {model.register_value:x}")
+            model.emulator.reg_write(model.address_register, model.register_value)
+            model.address_register = -1
+            return
+
+        if model.fauty_instruction_addr != address:
+            return
+        
+        ## Fix non-canonical address
         for mem_op in model.current_instruction.get_mem_operands():
             registers = re.split(r'\+|-|\*| ', mem_op.value)
             if len(registers) > 1:
                 continue
-
+            
             uc_reg = X86UnicornTargetDesc.reg_str_to_constant[registers[0]]
-            address = model.emulator.reg_read(uc_reg)  # load address
-            if address & (1 << 47):  # bit 48 is 1 => high address
-                address = address | 0xFFFF800000000000
-            else:  # bit 48 is 0 => low address
-                address = address & 0x00007FFFFFFFFFF
-            model.emulator.reg_write(uc_reg, address)
-            return  # Continue execution with canonical address
-
+            load_address = model.emulator.reg_read(uc_reg)  # load address
+            isCanonical : bool = load_address > 0xFFFF800000000000 \
+                or load_address < 0x00007FFFFFFFFFFF
+            if not isCanonical:
+                model.address_register  = uc_reg
+                model.register_value = load_address
+                
+                if load_address & (1 << 47):  # bit 48 is 1 => high address
+                    load_address = load_address | 0xFFFF800000000000
+                else:  # bit 48 is 0 => low address
+                    load_address = load_address & 0x00007FFFFFFFFFF
+                model.emulator.reg_write(uc_reg, load_address)
+                return
         return
 
     def reset_model(self):
         self.fauty_instruction_addr = -1
+        self.address_register = -1
+        self.register_value = -1
         return super().reset_model()
 
 

--- a/src/x86/x86_model.py
+++ b/src/x86/x86_model.py
@@ -917,7 +917,6 @@ class X86NonCanonicalAddress(X86FaultModelAbstract):
             return
 
         if model.address_register != -1:
-            print(f"write in {model.address_register} value {model.register_value:x}")
             model.emulator.reg_write(model.address_register, model.register_value)
             model.address_register = -1
             return

--- a/src/x86/x86_model.py
+++ b/src/x86/x86_model.py
@@ -866,6 +866,10 @@ class X86NonCanonicalAddress(X86FaultModelAbstract):
         super().__init__(*args)
         self.relevant_faults.update([6, 7])
 
+    def _load_input(self, input_: Input):
+        self.last_faulty_addr = -1
+        return super()._load_input(input_)
+
     def speculate_fault(self, errno: int) -> int:
         if not self.fault_triggers_speculation(errno):
             return 0
@@ -889,10 +893,8 @@ class X86NonCanonicalAddress(X86FaultModelAbstract):
             uc_reg = X86UnicornTargetDesc.reg_str_to_constant[registers[0]]
             address = model.emulator.reg_read(uc_reg)  # load address
             if address & (1 << 47):  # bit 48 is 1 => high address
-                # print(f"High address {address:x}")
                 address = address | 0xFFFF800000000000
             else:  # bit 48 is 0 => low address
-                # print(f"Low address: {address:x}")
                 address = address & 0x00007FFFFFFFFFF
             model.emulator.reg_write(uc_reg, address)
             return  # Continue execution with canonical address


### PR DESCRIPTION
This PR contains several fixes to the noncanonical contract.

1. In the generator I create a deepcopy of the operands when inserting instrumentation. Otherwise further instrumentation that modifies the instrumented instruction's operand also modifies the instrumentation instructions ' operands.
2.  In the noncanonical contract, during handling of the GP exception, we overwrite the register that contains the address. We need to restore its content afterward. 
3. In the noncanonical address pass  we prevent registers reuse. This makes the contract implementation logic simpler. We  avoid cases where the destination is partially overwritten and should be properly restored after the exception. 