### PR TITLE
CMOV* support to vops contract

### DIFF
--- a/src/x86/x86_model.py
+++ b/src/x86/x86_model.py
@@ -29,6 +29,29 @@ FLAGS_DF = 0b010000000000
 FLAGS_OF = 0b100000000000
 
 
+cmov_condition = {
+    "CMOVB": lambda flag: ((flag & FLAGS_CF) != 0),                                 # CF=1
+    "CMOVBE": lambda flag: (flag & (FLAGS_CF | FLAGS_ZF) != 0),                     # CF=1 or ZF=1
+    "CMOVL": lambda flag: (((flag & FLAGS_SF) != 0) != ((flag & FLAGS_OF) != 0)),   # SF<>OF
+    "CMOVLE": lambda flag: ((((flag & FLAGS_SF) != 0) != ((flag & FLAGS_OF) != 0))
+                            or ((flag & FLAGS_ZF) != 0)),                           # ZF=1 or SF<>OF
+    "CMOVNB": lambda flag: (flag & FLAGS_CF == 0),                                  # CF=0
+    "CMOVNBE": lambda flag: (((flag & FLAGS_CF) == 0)
+                             and ((flag & FLAGS_ZF) == 0)),                         # CF=0 and ZF=0
+    "CMOVNL": lambda flag: (((flag & FLAGS_SF) != 0) == ((flag & FLAGS_OF) != 0)),  # SF=OF
+    "CMOVNLE": lambda flag: (((flag & FLAGS_ZF) == 0)
+                             and ((flag & FLAGS_OF) == 0)),                         # ZF=0 and SF=OF
+    "CMOVNO": lambda flag: ((flag & FLAGS_OF) == 0),                                # OF=0
+    "CMOVNP": lambda flag: ((flag & FLAGS_PF) == 0),                                # PF=0
+    "CMOVNS": lambda flag: ((flag & FLAGS_SF) == 0),                                # SF=0
+    "CMOVNZ": lambda flag: ((flag & FLAGS_ZF) == 0),                                # ZF=0
+    "CMOVO": lambda flag: ((flag & FLAGS_OF) != 0),                                 # OF=1
+    "CMOVP": lambda flag: ((flag & FLAGS_PF) != 0),                                 # PF=1
+    "CMOVS": lambda flag: ((flag & FLAGS_SF) != 0),                                 # SF=1
+    "CMOVZ": lambda flag: ((flag & FLAGS_ZF) != 0),                                 # ZF=1
+}
+
+
 class X86UnicornModel(UnicornModel):
     """
     Base class that serves as main interface.
@@ -953,6 +976,55 @@ class X86UnicornVspecOps(X86FaultModelAbstract):
     def get_rollback_address(self) -> int:
         # faults end program execution
         return self.code_end
+
+    @staticmethod
+    def try_enable_conditional_move(model):
+        """
+        Try to modify tainted bits in the flag register to make conditional move happen.
+        """
+        current = model.emulator.reg_read(ucc.UC_X86_REG_EFLAGS)
+        read_flag = model.current_instruction.get_flags_operand().get_read_flags()
+        tainted_flags = [f for f in read_flag if f in model.reg_taints]
+
+        flag = current
+        name = model.current_instruction.name
+        condition = cmov_condition[name]
+
+        # if the cmov is already enable or flags are not tainted than skip
+        if len(tainted_flags) != 0 and not condition(current):
+            if name in ["CMOVB", "CMOVO", "CMOVP", "CMOVP", "CMOVZ"]:
+                assert (len(tainted_flags) == 1)
+                flag |= model.flags_translate[read_flag[0]]
+            elif name in ["CMOVNO", "CMOVNP", "CMOVNS", "CMOVNZ"]:
+                assert (len(tainted_flags) == 1)
+                flag &= ~model.flags_translate[read_flag[0]]
+            elif "CMOVBE" == name:
+                flag |= FLAGS_CF if ("CF" in tainted_flags) else FLAGS_ZF
+            elif "CMOVL" == name:
+                flag ^= FLAGS_SF if ("SF" in tainted_flags) else FLAGS_OF
+            elif "CMOVLE" == name:
+                if "ZF" in tainted_flags:
+                    flag |= FLAGS_ZF
+                else:
+                    flag ^= FLAGS_SF if ("SF" in tainted_flags) else FLAGS_OF
+            elif "CMOVNBE" == name:
+                if "CF" in tainted_flags:
+                    flag &= ~FLAGS_CF
+                if "ZF" in tainted_flags:
+                    flag &= ~FLAGS_ZF
+            elif "CMOVNL" == name:
+                if "SF" in tainted_flags:
+                    flag ^= FLAGS_SF
+                elif "OF" in tainted_flags:
+                    flag ^= FLAGS_OF
+            elif "CMOVNLE" == name:
+                if "ZF" in tainted_flags:
+                    flag &= ~FLAGS_ZF
+                if "OF" in tainted_flags:
+                    flag &= ~FLAGS_OF
+
+        if flag != current:
+            model.emulator.reg_write(ucc.UC_X86_REG_EFLAGS, flag)
 
 
 class x86UnicornVspecOpsDIV(X86UnicornVspecOps):

--- a/src/x86/x86_model.py
+++ b/src/x86/x86_model.py
@@ -1002,16 +1002,6 @@ class X86UnicornVspecOps(X86FaultModelAbstract):
                 flag |= FLAGS_CF if ("CF" in tainted_flags) else FLAGS_ZF
             elif "CMOVL" == name:
                 flag ^= FLAGS_SF if ("SF" in tainted_flags) else FLAGS_OF
-            elif "CMOVNBE" == name:
-                if "CF" in tainted_flags:
-                    flag &= ~FLAGS_CF
-                if "ZF" in tainted_flags:
-                    flag &= ~FLAGS_ZF
-            elif "CMOVNL" == name:
-                if "SF" in tainted_flags:
-                    flag ^= FLAGS_SF
-                elif "OF" in tainted_flags:
-                    flag ^= FLAGS_OF
             elif "CMOVLE" == name:
                 if "ZF" in tainted_flags:
                     flag |= FLAGS_ZF
@@ -1030,6 +1020,16 @@ class X86UnicornVspecOps(X86FaultModelAbstract):
                         flag ^= FLAGS_SF
                     elif "OF" in tainted_flags:
                         flag ^= FLAGS_OF
+            elif "CMOVNBE" == name:
+                if "CF" in tainted_flags:
+                    flag &= ~FLAGS_CF
+                if "ZF" in tainted_flags:
+                    flag &= ~FLAGS_ZF
+            elif "CMOVNL" == name:
+                if "SF" in tainted_flags:
+                    flag ^= FLAGS_SF
+                elif "OF" in tainted_flags:
+                    flag ^= FLAGS_OF
 
         if flag != current:
             model.emulator.reg_write(ucc.UC_X86_REG_EFLAGS, flag)

--- a/src/x86/x86_model.py
+++ b/src/x86/x86_model.py
@@ -39,8 +39,8 @@ cmov_condition = {
     "CMOVNBE": lambda flag: (((flag & FLAGS_CF) == 0)
                              and ((flag & FLAGS_ZF) == 0)),                         # CF=0 and ZF=0
     "CMOVNL": lambda flag: (((flag & FLAGS_SF) != 0) == ((flag & FLAGS_OF) != 0)),  # SF=OF
-    "CMOVNLE": lambda flag: (((flag & FLAGS_ZF) == 0)
-                             and ((flag & FLAGS_OF) == 0)),                         # ZF=0 and SF=OF
+    "CMOVNLE": lambda flag: (((flag & FLAGS_ZF) == 0)                               # ZF=0 and SF=OF
+                             and ((flag & FLAGS_SF) != 0) == ((flag & FLAGS_OF) != 0)),
     "CMOVNO": lambda flag: ((flag & FLAGS_OF) == 0),                                # OF=0
     "CMOVNP": lambda flag: ((flag & FLAGS_PF) == 0),                                # PF=0
     "CMOVNS": lambda flag: ((flag & FLAGS_SF) == 0),                                # SF=0
@@ -1002,11 +1002,6 @@ class X86UnicornVspecOps(X86FaultModelAbstract):
                 flag |= FLAGS_CF if ("CF" in tainted_flags) else FLAGS_ZF
             elif "CMOVL" == name:
                 flag ^= FLAGS_SF if ("SF" in tainted_flags) else FLAGS_OF
-            elif "CMOVLE" == name:
-                if "ZF" in tainted_flags:
-                    flag |= FLAGS_ZF
-                else:
-                    flag ^= FLAGS_SF if ("SF" in tainted_flags) else FLAGS_OF
             elif "CMOVNBE" == name:
                 if "CF" in tainted_flags:
                     flag &= ~FLAGS_CF
@@ -1017,11 +1012,24 @@ class X86UnicornVspecOps(X86FaultModelAbstract):
                     flag ^= FLAGS_SF
                 elif "OF" in tainted_flags:
                     flag ^= FLAGS_OF
+            elif "CMOVLE" == name:
+                if "ZF" in tainted_flags:
+                    flag |= FLAGS_ZF
+                elif ((FLAGS_SF & current) != 0) == ((FLAGS_OF & current) != 0):
+                    # SF=OF than flip one of them
+                    if "SF" in tainted_flags:
+                        flag ^= FLAGS_SF
+                    elif "OF" in tainted_flags:
+                        flag ^= FLAGS_OF
             elif "CMOVNLE" == name:
                 if "ZF" in tainted_flags:
                     flag &= ~FLAGS_ZF
-                if "OF" in tainted_flags:
-                    flag &= ~FLAGS_OF
+                if ((FLAGS_SF & current) != 0) != ((FLAGS_OF & current) != 0):
+                    # SF<>OF than flip one of them
+                    if "SF" in tainted_flags:
+                        flag ^= FLAGS_SF
+                    elif "OF" in tainted_flags:
+                        flag ^= FLAGS_OF
 
         if flag != current:
             model.emulator.reg_write(ucc.UC_X86_REG_EFLAGS, flag)

--- a/src/x86/x86_target_desc.py
+++ b/src/x86/x86_target_desc.py
@@ -105,6 +105,10 @@ class X86TargetDesc(TargetDesc):
     def is_call(inst: Instruction) -> bool:
         return inst.category == "BASE-CALL"
 
+    @staticmethod
+    def is_conditional_move(inst: Instruction) -> bool:
+        return inst.category == "BASE-CMOV"
+
 
 class X86UnicornTargetDesc(UnicornTargetDesc):
     reg_str_to_constant = {


### PR DESCRIPTION
Before CMOV* executes we try to modify tainted bits in the flag register to make the cmov happen.

It ended up being a bunch of if/else to set the flags that enable the conditional move. 
Code is not really readable but it's the only way I could think it. 
