### PR TITLE
Updates to Immediate Generation and Input Generation

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -59,6 +59,9 @@ class ConfCls:
     for correctness """
     register_blocklist: List[str] = []
     """ register_blocklist: list of registers that will NOT be used for generating programs """
+    input_entropy_for_imm: bool = False
+    """ Applies bounds on immediate values based on the entropy parameter applied to inputs,
+    Note: this does not apply to bitmasks """
     avoid_data_dependencies: bool = False
     """ [DEPRECATED] avoid_data_dependencies: """
     generate_memory_accesses_in_pairs: bool = False

--- a/src/generator.py
+++ b/src/generator.py
@@ -471,9 +471,37 @@ class RandomGenerator(ConfigurableGenerator, abc.ABC):
     def generate_imm_operand(self, spec: OperandSpec, _: Instruction) -> Operand:
         if spec.values:
             if spec.values[0] == "bitmask":
-                # FIXME: this implementation always returns the same bitmask
-                # make it random
-                value = str(pow(2, spec.width) - 2)
+                assert CONF.instruction_set == "arm64"
+
+                if spec.width == 64:
+                    imms_zero_pos = random.randint(1, 6)
+                else:
+                    imms_zero_pos = random.randint(1, 5)
+                imms_ones = random.randint(1, 2 ** imms_zero_pos - 1)
+
+                if imms_zero_pos == 6:
+                    n = 1
+                else:
+                    n = 0
+                imms = ((0b111110 << imms_zero_pos) & 0b111111) + imms_ones
+                immr = random.randint(0, spec.width - 1)
+
+                pattern = "0" * (2 ** imms_zero_pos - imms_ones) + "1" * imms_ones
+                multiplier = spec.width // (2 ** imms_zero_pos)
+                value_str = pattern * multiplier
+                value = int(value_str, 2)
+                value = (value >> immr)|(value << (spec.width - immr)) & (2 ** spec.width - 1)
+
+                # Debug:
+                # print(f"N: {n}, imms: {imms:06b}, immr: {immr:06b}, imms_zero_pos: {imms_zero_pos}, imms_ones: {imms_ones:06b}")
+                # print(f"pattern: {pattern}")
+                # print(f"multiplier: {multiplier}")
+                # print(f"value: 0b{value:064b}")
+
+                if spec.width == 64:
+                    value = f"0x{value:016x}"
+                else:
+                    value = f"0x{value:08x}"
             else:
                 assert "[" in spec.values[0], spec.values
                 range_ = spec.values[0][1:-1].split("-")
@@ -481,6 +509,21 @@ class RandomGenerator(ConfigurableGenerator, abc.ABC):
                     range_ = range_[1:]
                     range_[0] = "-" + range_[0]
                 assert len(range_) == 2
+
+                # Constrain the immediate value to the maximum value allowed
+                # by using input_gen_entropy_bits of the immediate
+                if CONF.input_entropy_for_imm:
+                    max_imm_vals = 2 ** CONF.input_gen_entropy_bits
+                    op_imm_max = int(range_[1]) - int(range_[0]) + 1
+                    if op_imm_max > max_imm_vals:
+                        if int(range_[0]) < 0:
+                            # Signed imm
+                            range_[0] = f"-{max_imm_vals // 2}"
+                            range_[1] = f"{max_imm_vals // 2 - 1}"
+                        else:
+                            # Unsigned imm
+                            range_[1] = f"{max_imm_vals - 1}"
+
                 value = str(random.randint(int(range_[0]), int(range_[1])))
         else:
             value = str(random.randint(pow(2, spec.width - 1) * -1, pow(2, spec.width - 1) - 1))

--- a/src/generator.py
+++ b/src/generator.py
@@ -479,11 +479,6 @@ class RandomGenerator(ConfigurableGenerator, abc.ABC):
                     imms_zero_pos = random.randint(1, 5)
                 imms_ones = random.randint(1, 2 ** imms_zero_pos - 1)
 
-                if imms_zero_pos == 6:
-                    n = 1
-                else:
-                    n = 0
-                imms = ((0b111110 << imms_zero_pos) & 0b111111) + imms_ones
                 immr = random.randint(0, spec.width - 1)
 
                 pattern = "0" * (2 ** imms_zero_pos - imms_ones) + "1" * imms_ones
@@ -491,12 +486,6 @@ class RandomGenerator(ConfigurableGenerator, abc.ABC):
                 value_str = pattern * multiplier
                 value = int(value_str, 2)
                 value = (value >> immr)|(value << (spec.width - immr)) & (2 ** spec.width - 1)
-
-                # Debug:
-                # print(f"N: {n}, imms: {imms:06b}, immr: {immr:06b}, imms_zero_pos: {imms_zero_pos}, imms_ones: {imms_ones:06b}")
-                # print(f"pattern: {pattern}")
-                # print(f"multiplier: {multiplier}")
-                # print(f"value: 0b{value:064b}")
 
                 if spec.width == 64:
                     value = f"0x{value:016x}"

--- a/src/interfaces.py
+++ b/src/interfaces.py
@@ -561,7 +561,7 @@ class Input(np.ndarray):
             return
 
     def get_registers(self):
-        return list(self[self.register_start:self.data_size - 1])
+        return list(self[self.register_start:self.data_size])
 
     def get_memory(self):
         return self[0:self.register_start]


### PR DESCRIPTION
Updates to Input.get_registers() to avoid slicing off the final 8 register bytes.

Add config option `input_entropy_for_imm` to constrain arithmetic immediate values to be constrained to the same number of values that can be held in the input registers based on entropy setting.

Add full randomization to ARM bitmask immediates. This is currently in the RandomGenerator class but could be moved to Arch specific generators if needed. Currently it asserts only arm64 should be using bitmask immediates.