### PR TITLE
fuzzer: fast-path executor and other optimizations

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -100,6 +100,8 @@ class ConfCls:
     """ contract_execution_clause: """
     contract_observation_clause: str = 'ct'
     """ contract_observation_clause: """
+    model_min_nesting: int = 1
+    """ model_max_nesting: """
     model_max_nesting: int = 30
     """ model_max_nesting: """
     model_max_spec_window: int = 250
@@ -134,7 +136,7 @@ class ConfCls:
     analyser_permit_subsets: bool = True
     """ analyser_permit_subsets: if enabled, the analyser will not label hardware traces
     as mismatching if they form a subset relation """
-    
+
     # ==============================================================================================
     # Coverage
     coverage_type: str = 'none'

--- a/src/config.py
+++ b/src/config.py
@@ -26,6 +26,14 @@ class ConfCls:
     """ enable_speculation_filter: if True, discard test cases that don't trigger speculation"""
     enable_observation_filter: bool = False
     """ enable_observation_filter: if True,discard test cases that don't leave speculative traces"""
+    enable_fast_path_model: bool = True
+    """ enable_fast_path_boosting: if enabled, the same contract trace will be used
+    for all inputs in the same taint-based input class """
+    enable_fast_path_executor: bool = True
+    """ enable_fast_path_executor: if True, the executor will first collect hardware traces
+    with (almost) no noise filtering, and will re-collect traces with noise filtering if
+    a violation is detected
+    """
 
     # ==============================================================================================
     # Execution Environment
@@ -106,9 +114,6 @@ class ConfCls:
     """ model_max_nesting: """
     model_max_spec_window: int = 250
     """ model_max_spec_window: """
-    model_taint_based_ctraces: bool = True
-    """ model_taint_based_ctraces: if enabled, the same contract trace will be used
-    for all inputs in the same taint-based input class """
 
     # ==============================================================================================
     # Executor

--- a/src/fuzzer.py
+++ b/src/fuzzer.py
@@ -165,6 +165,7 @@ class Fuzzer:
         if CONF.model_min_nesting < CONF.model_max_nesting and \
            "seq" not in CONF.contract_execution_clause and \
            "no_speculation" not in CONF.contract_execution_clause:
+            self.input_gen.reset_boosting_state()
             ctraces, boosted_inputs = self.trace_and_boost(inputs, CONF.model_max_nesting)
             if CONF.enable_fast_path_executor:
                 htraces = self.executor.trace_test_case(

--- a/src/fuzzer.py
+++ b/src/fuzzer.py
@@ -184,6 +184,7 @@ class Fuzzer:
         #     and check if the violation persists
         if CONF.enable_fast_path_executor:  # only makes sense if fast path was enabled
             htraces = self.executor.trace_test_case(boosted_inputs)
+            feedback = self.executor.get_last_feedback()
             violations = self.analyser.filter_violations(boosted_inputs, ctraces, htraces)
             if not violations:
                 STAT.fp_noise += 1

--- a/src/interfaces.py
+++ b/src/interfaces.py
@@ -776,6 +776,10 @@ class InputGenerator(ABC):
         return self._state
 
     @abstractmethod
+    def reset_boosting_state(self) -> None:
+        pass
+
+    @abstractmethod
     def generate(self, count: int) -> List[Input]:
         pass
 

--- a/src/interfaces.py
+++ b/src/interfaces.py
@@ -567,7 +567,7 @@ class Input(np.ndarray):
         if obj is None:
             return
 
-    def __hash__(self) -> int:
+    def __hash__(self) -> int:  # type: ignore
         # hash of input is hash of input data, registers and memory
         return hash(tuple(self[0:self.data_size - 1]))
 
@@ -878,7 +878,10 @@ class Executor(ABC):
         pass
 
     @abstractmethod
-    def trace_test_case(self, inputs: List[Input], repetitions: int = 0) -> List[CombinedHTrace]:
+    def trace_test_case(self,
+                        inputs: List[Input],
+                        repetitions: int = 0,
+                        threshold_outliers: int = 0) -> List[CombinedHTrace]:
         pass
 
     @abstractmethod

--- a/src/util.py
+++ b/src/util.py
@@ -33,14 +33,17 @@ class StatisticsCls:
     num_inputs: int = 0
     eff_classes: int = 0
     single_entry_classes: int = 0
-    required_priming: int = 0
-    flaky_violations: int = 0
-    taint_mistakes: int = 0
     violations: int = 0
     coverage: int = 0
     analysed_test_cases: int = 0
     spec_filter: int = 0
     observ_filter: int = 0
+    no_fast_violation: int = 0
+    fp_noise: int = 0
+    fp_nesting: int = 0
+    fp_taint_mistakes: int = 0
+    fp_flaky: int = 0
+    fp_priming: int = 0
 
     # Implementation of Borg pattern
     def __init__(self) -> None:
@@ -48,7 +51,6 @@ class StatisticsCls:
 
     def __str__(self):
         total_clss = self.eff_classes + self.single_entry_classes
-        effectiveness = self.eff_classes / total_clss if total_clss else 0
         total_clss_per_test_case = total_clss / self.analysed_test_cases \
             if self.analysed_test_cases else 0
         effective_clss = self.eff_classes / self.analysed_test_cases \
@@ -58,17 +60,19 @@ class StatisticsCls:
         s = ""
         s += f"Test Cases: {self.test_cases}\n"
         s += f"Inputs per test case: {iptc:.1f}\n"
-        s += f"Flaky violations: {self.flaky_violations}\n"
-        s += f"Taint-based false positives: {self.taint_mistakes}\n"
-        s += f"Required priming: {self.required_priming}\n"
         s += f"Violations: {self.violations}\n"
         s += "Effectiveness: \n"
-        s += f"  Effectiveness: {effectiveness:.1f}\n"
         s += f"  Total Cls: {total_clss_per_test_case:.1f}\n"
         s += f"  Effective Cls: {effective_clss:.1f}\n"
-        s += "Filters:\n"
+        s += "Discarded Test Cases:\n"
         s += f"  Speculation Filter: {self.spec_filter}\n"
         s += f"  Observation Filter: {self.observ_filter}\n"
+        s += f"  No Fast-Path Violation: {self.no_fast_violation}\n"
+        s += f"  Noise-Based FP: {self.fp_noise}\n"
+        s += f"  No Max-Nesting Violation: {self.fp_nesting}\n"
+        s += f"  Tainting Mistakes: {self.fp_taint_mistakes}\n"
+        s += f"  Flaky Tests: {self.fp_flaky}\n"
+        s += f"  Priming Check: {self.fp_priming}\n"
         return s
 
     def get_brief(self):
@@ -83,13 +87,14 @@ class StatisticsCls:
                 eff_cls = 0
             s = f"Cls:{eff_cls:.1f}/{all_cls:.1f},"
             s += f"In:{self.num_inputs / self.test_cases:.1f},"
-            s += f"Cv:{self.coverage},"
-            s += f"SpF:{self.spec_filter},"
-            s += f"ObF:{self.observ_filter},"
-            s += f"Prm:{self.required_priming}," \
-                 f"Flk:{self.flaky_violations}," \
-                 f"TbM:{self.taint_mistakes}," \
-                 f"Vio:{self.violations}"
+            s += f"SF:{self.spec_filter},"
+            s += f"OF:{self.observ_filter},"
+            s += f"NE:{self.fp_nesting}," \
+                 f"NO:{self.fp_noise}," \
+                 f"TM:{self.fp_taint_mistakes}," \
+                 f"FL:{self.fp_flaky}," \
+                 f"PR:{self.fp_priming}," \
+                 f"V:{self.violations}"
             return s
 
 

--- a/src/x86/x86_executor.py
+++ b/src/x86/x86_executor.py
@@ -75,8 +75,10 @@ class X86Executor(Executor):
         with open(test_case.bin_path, "rb") as f:
             write_to_sysfs_file_bytes(f.read(), "/sys/x86_executor/test_case")
 
-    def trace_test_case(self, inputs: List[Input], repetitions: int = 0) \
-            -> List[CombinedHTrace]:
+    def trace_test_case(self,
+                        inputs: List[Input],
+                        repetitions: int = 0,
+                        threshold_outliers: int = 0) -> List[CombinedHTrace]:
         # make sure it's not a dummy call
         if not inputs:
             return []
@@ -84,7 +86,7 @@ class X86Executor(Executor):
         if repetitions == 0:
             repetitions = CONF.executor_repetitions
             threshold_outliers = CONF.executor_max_outliers
-        else:
+        elif threshold_outliers == 0:
             threshold_outliers = repetitions // 10
 
         # convert the inputs into a byte sequence
@@ -165,11 +167,13 @@ class X86Executor(Executor):
 
 
 class X86IntelExecutor(X86Executor):
+
     def set_vendor_specific_features(self):
         write_to_sysfs_file("1" if "BR" in CONF.permitted_faults else "0",
                             "/sys/x86_executor/enable_mpx")
 
 
 class X86AMDExecutor(X86Executor):
+
     def set_vendor_specific_features(self):
         pass

--- a/src/x86/x86_fuzzer.py
+++ b/src/x86/x86_fuzzer.py
@@ -97,8 +97,8 @@ class X86Fuzzer(Fuzzer):
                 if pfc_values[0] > pfc_values[1] or pfc_values[2] > 0:
                     break
             else:
+                STAT.spec_filter += 1
                 return True
-            STAT.spec_filter += 1
 
         # 2. Observation filter:
         # Check if any of the htraces contain a speculative cache eviction
@@ -113,9 +113,8 @@ class X86Fuzzer(Fuzzer):
             fenced_htraces = self.executor.trace_test_case(inputs, repetitions=1)
 
             if fenced_htraces == non_fenced_htraces:
+                STAT.observ_filter += 1
                 return True
-
-            STAT.observ_filter += 1
 
         return False
 


### PR DESCRIPTION
The PR introduces several changes to the overall fuzzing process:
- Introduces a config option `model_min_nesting` to optimize the throughput of experiments that experience a lot of benign nested mispredictions (bada76a) 
- Adds a fast-path hardware tracing option that collects htraces first without filtering and, if a violation is detected, enabled noise filtering and re-collectrs htraces (34ccc5874cd78ae35ecac38f7b2ff34eaf4524d1)
- Separates the input generator state into main state (updated when generating the original batch of inputs) and boosting state (updated when boosting inputs). The later is reset when the fuzzer re-boosts the same batch of inputs, to ensure consistent results (c7a852d12267cbb26e338acc0162bbb206deb181)
- (minor) Refactors statistics on false positives

Co-authored-by: @janahofmann