### PR TITLE
Update for AMD CPU family 23

### DIFF
--- a/src/x86/executor/Makefile
+++ b/src/x86/executor/Makefile
@@ -4,10 +4,15 @@ ifneq ($(shell grep "Intel" /proc/cpuinfo),)
 	VENDOR_ID=1
 else ifneq ($(shell grep "AMD" /proc/cpuinfo),)
 	VENDOR_ID=2
+ifneq ($(shell grep -m1 "cpu family" /proc/cpuinfo | grep "23" ),)
+	CPU_FAMILY=23
+else
+	CPU_FAMILY=25 # Default to 19h
+endif
 endif
 
 ccflags-y += -std=gnu11 -Wno-declaration-after-statement -DL1D_ASSOCIATIVITY=$(shell cat /sys/devices/system/cpu/cpu0/cache/index0/ways_of_associativity) \
-	\-DVENDOR_ID=$(VENDOR_ID)
+	\-DVENDOR_ID=$(VENDOR_ID) -DCPU_FAMILY=$(CPU_FAMILY)
 
 obj-m += $(NAME).o
 $(NAME)-objs += main.o templates.o measurement.o


### PR DESCRIPTION
We use the following performance counters from BKDG manual for 15h and 16h family.
-  Disable prefetcher via MSRC001_1022 "Data Cache Configuration" (DC_CFG)
-  Use PFC43 "Data Cache Refills from System" rather than PFC44 (not available) 
-  Only Zen 2 got an architectural MSR for speculation control. ssbp_patch_control is not available on Zen+. 