### PR TITLE
x86/executor: add quick-and-dirty measurement for faster pre-filtering

### DIFF
--- a/src/util.py
+++ b/src/util.py
@@ -80,16 +80,17 @@ class StatisticsCls:
             return ""
         else:
             if self.analysed_test_cases:
-                all_cls = (self.eff_classes + self.single_entry_classes) / self.analysed_test_cases
-                eff_cls = self.eff_classes / self.analysed_test_cases
+                all_cls = (self.eff_classes + self.single_entry_classes) // self.analysed_test_cases
+                eff_cls = self.eff_classes // self.analysed_test_cases
             else:
                 all_cls = 0
                 eff_cls = 0
-            s = f"Cls:{eff_cls:.1f}/{all_cls:.1f},"
-            s += f"In:{self.num_inputs / self.test_cases:.1f},"
+            s = f"Cls:{eff_cls}/{all_cls},"
+            s += f"In:{self.num_inputs // self.test_cases},"
             s += f"SF:{self.spec_filter},"
             s += f"OF:{self.observ_filter},"
-            s += f"NE:{self.fp_nesting}," \
+            s += f"FV:{self.no_fast_violation}," \
+                 f"NE:{self.fp_nesting}," \
                  f"NO:{self.fp_noise}," \
                  f"TM:{self.fp_taint_mistakes}," \
                  f"FL:{self.fp_flaky}," \

--- a/src/x86/executor/main.h
+++ b/src/x86/executor/main.h
@@ -41,6 +41,7 @@
 #endif
 
 // Executor Configuration Interface
+extern bool quick_and_dirty_mode;
 extern long uarch_reset_rounds;
 #define UARCH_RESET_ROUNDS_DEFAULT 1
 extern uint64_t ssbp_patch_control;
@@ -120,7 +121,9 @@ extern pteval_t faulty_pte_mask_clear;
 int trace_test_case(void);
 int load_template(size_t tc_size);
 void template_l1d_prime_probe(void);
+void template_l1d_prime_probe_fast(void);
 void template_l1d_prime_probe_partial(void);
+void template_l1d_prime_probe_partial_fast(void);
 void template_l1d_flush_reload(void);
 void template_l1d_evict_reload(void);
 void template_gpr(void);

--- a/src/x86/executor/templates.c
+++ b/src/x86/executor/templates.c
@@ -481,6 +481,45 @@ void template_l1d_prime_probe(void) {
     asm volatile(".quad "xstr(TEMPLATE_RETURN));
 }
 
+void template_l1d_prime_probe_fast(void) {
+    asm volatile(".quad "xstr(TEMPLATE_ENTER));
+    prologue();
+
+    // Prime
+    // clobber: rax, rbx, rcx, rdx
+    asm_volatile_intel(""
+        "lea rax, [r14 - "xstr(EVICT_REGION_OFFSET)"]\n"
+        PRIME("rax", "rbx", "rcx", "rdx", "1"));
+
+    // PFC
+    // clobber: rax, rcx, rdx
+    asm_volatile_intel(READ_PFC_START());
+
+    // Initialize registers
+    SET_REGISTER_FROM_INPUT();
+
+    PIPELINE_RESET();
+
+    // Execute the test case
+    asm("\nlfence\n"
+        ".quad "xstr(TEMPLATE_INSERT_TC)" \n"
+        "mfence\n");
+
+    asm(".quad "xstr(TEMPLATE_JUMP_EXCEPTION));
+
+    // PFC
+    asm_volatile_intel(READ_PFC_END());
+
+    // Probe and store the resulting eviction bitmap map into r11
+    // Note: it internally clobbers rcx, rdx, rax
+    asm_volatile_intel(""
+        "lea r15, [r14 - "xstr(EVICT_REGION_OFFSET)"]\n"
+        PROBE("r15", "rbx", "r13", "r11"));
+
+    epilogue();
+    asm volatile(".quad "xstr(TEMPLATE_RETURN));
+}
+
 // =================================================================================================
 // L1D Prime+Probe applied to a subset of L1D instead the whole cache
 // =================================================================================================
@@ -505,6 +544,45 @@ void template_l1d_prime_probe_partial(void) {
     asm_volatile_intel(""
         "lea rax, [r14 - "xstr(EVICT_REGION_OFFSET)"]\n"
         PRIME_PARTIAL("rax", "rbx", "rcx", "rdx", "32"));
+
+    // PFC
+    // clobber: rax, rcx, rdx
+    asm_volatile_intel(READ_PFC_START());
+
+    // Initialize registers
+    SET_REGISTER_FROM_INPUT();
+
+    PIPELINE_RESET();
+
+    // Execute the test case
+    asm("\nlfence\n"
+        ".quad "xstr(TEMPLATE_INSERT_TC)" \n"
+        "mfence\n");
+
+    asm(".quad "xstr(TEMPLATE_JUMP_EXCEPTION));
+
+    // PFC
+    asm_volatile_intel(READ_PFC_END());
+
+    // Probe and store the resulting eviction bitmap map into r11
+    // Note: it internally clobbers rcx, rdx, rax
+    asm_volatile_intel(""
+        "lea r15, [r14 - "xstr(EVICT_REGION_OFFSET)"]\n"
+        PROBE("r15", "rbx", "r13", "r11"));
+
+    epilogue();
+    asm volatile(".quad "xstr(TEMPLATE_RETURN));
+}
+
+void template_l1d_prime_probe_partial_fast(void) {
+    asm volatile(".quad "xstr(TEMPLATE_ENTER));
+    prologue();
+
+    // Prime
+    // clobber: rax, rbx, rcx, rdx
+    asm_volatile_intel(""
+        "lea rax, [r14 - "xstr(EVICT_REGION_OFFSET)"]\n"
+        PRIME_PARTIAL("rax", "rbx", "rcx", "rdx", "1"));
 
     // PFC
     // clobber: rax, rcx, rdx

--- a/src/x86/x86_executor.py
+++ b/src/x86/x86_executor.py
@@ -11,7 +11,7 @@ from ..util import Logger
 
 
 def write_to_sysfs_file(value, path: str) -> None:
-    subprocess.run(f"sudo bash -c 'echo -n {value} > {path}'", shell=True, check=True)
+    subprocess.run(f"echo -n {value} > {path}", shell=True, check=True)
 
 
 def write_to_sysfs_file_bytes(value: bytes, path: str) -> None:
@@ -65,6 +65,9 @@ class X86Executor(Executor):
         write_to_sysfs_file("1" if CONF.enable_pre_run_flush else "0",
                             "/sys/x86_executor/enable_pre_run_flush")
         write_to_sysfs_file(CONF.executor_mode, "/sys/x86_executor/measurement_mode")
+
+    def set_quick_and_dirty(self, state: bool):
+        write_to_sysfs_file("1" if state else "0", "/sys/x86_executor/enable_quick_and_dirty_mode")
 
     def set_vendor_specific_features(self):
         pass

--- a/src/x86/x86_fuzzer.py
+++ b/src/x86/x86_fuzzer.py
@@ -83,6 +83,7 @@ class X86Fuzzer(Fuzzer):
     def filter(self, test_case: TestCase, inputs: List[Input]) -> bool:
         """ This function implements a multi-stage algorithm that gradually filters out
         uninteresting test cases """
+        self.executor.set_quick_and_dirty(True)
         if CONF.enable_speculation_filter or CONF.enable_observation_filter:
             self.executor.load_test_case(test_case)
             non_fenced_htraces = self.executor.trace_test_case(inputs, repetitions=1)
@@ -97,6 +98,7 @@ class X86Fuzzer(Fuzzer):
                 if pfc_values[0] > pfc_values[1] or pfc_values[2] > 0:
                     break
             else:
+                self.executor.set_quick_and_dirty(False)
                 STAT.spec_filter += 1
                 return True
 
@@ -113,9 +115,11 @@ class X86Fuzzer(Fuzzer):
             fenced_htraces = self.executor.trace_test_case(inputs, repetitions=1)
 
             if fenced_htraces == non_fenced_htraces:
+                self.executor.set_quick_and_dirty(False)
                 STAT.observ_filter += 1
                 return True
 
+        self.executor.set_quick_and_dirty(False)
         return False
 
 


### PR DESCRIPTION
The PR introduces a new measurement mode that cuts a few corners in the measurement process to achieve considerably higher performance (as high as 10x faster on my benchmarks).

Namely, this mode:
* doesn't reset uarch state
* executes the Prime stage of P+P only once
* doesn't initialize overflow pages

These changes can lead to corrupted hardware traces. Accordingly, the mode is exclusively used by the filters (speculation and observation filters). It is not meant to be used for collecting hardware traces.