### PR TITLE
factory: add AMD executor

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -115,7 +115,7 @@ class ConfCls:
 
     # ==============================================================================================
     # Executor
-    executor: str = 'default'
+    executor: str = 'x86-64-intel'
     """ executor: executor type """
     executor_mode: str = 'P+P'
     """ executor_mode: hardware trace collection mode """

--- a/src/factory.py
+++ b/src/factory.py
@@ -57,7 +57,8 @@ X86_SIMPLE_EXECUTION_CLAUSES: Dict[str, Type[x86_model.X86UnicornModel]] = {
 }
 
 EXECUTORS = {
-    'x86-64': x86_executor.X86IntelExecutor,
+    'x86-64-intel': x86_executor.X86IntelExecutor,
+    'x86-64-amd': x86_executor.X86AMDExecutor,
 }
 
 ANALYSERS: Dict[str, Type[interfaces.Analyser]] = {
@@ -141,9 +142,7 @@ def get_model(bases: Tuple[int, int]) -> interfaces.Model:
 
 
 def get_executor() -> interfaces.Executor:
-    if CONF.executor != 'default':
-        raise ConfigException("ERROR: unknown value of `executor` configuration option")
-    return _get_from_config(EXECUTORS, CONF.instruction_set, "instruction_set")
+    return _get_from_config(EXECUTORS, CONF.executor, "executor")
 
 
 def get_analyser() -> interfaces.Analyser:

--- a/src/x86/x86_config.py
+++ b/src/x86/x86_config.py
@@ -8,6 +8,10 @@ from typing import List
 
 # x86_option_values attribute MUST be the first attribute in the file
 x86_option_values = {
+    'executor': [
+        'x86-64-intel',
+        'x86-64-amd',
+    ],
     'executor_mode': [
         'P+P',
         'F+R',

--- a/src/x86/x86_executor.py
+++ b/src/x86/x86_executor.py
@@ -171,12 +171,32 @@ class X86Executor(Executor):
 
 class X86IntelExecutor(X86Executor):
 
+    def __init__(self):
+        self.LOG = Logger()
+        vendor = subprocess.run(
+            "grep 'vendor_id' /proc/cpuinfo", shell=True, capture_output=True).stdout.decode()
+        if "Intel" not in vendor:
+            self.LOG.error(
+                "Attempting to run Intel executor on a non-Intel CPUs!\n"
+                "Change the `executor` configuration option to the appropriate vendor value.")
+        super().__init__()
+
     def set_vendor_specific_features(self):
         write_to_sysfs_file("1" if "BR" in CONF.permitted_faults else "0",
                             "/sys/x86_executor/enable_mpx")
 
 
 class X86AMDExecutor(X86Executor):
+
+    def __init__(self):
+        self.LOG = Logger()
+        vendor = subprocess.run(
+            "grep 'vendor_id' /proc/cpuinfo", shell=True, capture_output=True).stdout.decode()
+        if "AMD" not in vendor:
+            self.LOG.error(
+                "Attempting to run AMD executor on a non-AMD CPUs!\n"
+                "Change the `executor` configuration option to the appropriate vendor value.")
+        super().__init__()
 
     def set_vendor_specific_features(self):
         pass


### PR DESCRIPTION
The executor default to the intel one. 
An option to select the executor already exist but it is not used.
This PR adds two options for the executor: 'x86-64-intel' and 'x86-64-amd'.