### PR TITLE
Revert "x86/executor: migrate from SMI detection to detection of inte…

### DIFF
--- a/src/x86/executor/measurement.c
+++ b/src/x86/executor/measurement.c
@@ -180,11 +180,6 @@ static inline int pre_measurement_setup(void)
     //   from resteered path following branch misprediction or machine clear events.
     err |= config_pfc(3, "0D.01", 1, 1); // misprediction recovery cycles - fuzzing feedback
 
-    // #4: Interrupt detection
-    //    HW_INTERRUPTS.RECEIVED: Counts the number of hardware interruptions received
-    //    by the processor.
-    err |= config_pfc(4, "CB.01", 1, 1); // detection of interrupts
-
     // Configure uarch patches
     wrmsr64(MSR_IA32_SPEC_CTRL, ssbp_patch_control);
 


### PR DESCRIPTION
This reverts commit ddc36fa15fbb4025c60455e929396b0d1c4ef772.

This commit cause the system to crash on Intel when SMT is enabled. 