### PR TITLE
Add include in shortcuts.h

### DIFF
--- a/src/x86/executor/include/shortcuts.h
+++ b/src/x86/executor/include/shortcuts.h
@@ -8,6 +8,7 @@
 
 #include <linux/kernel.h>
 #include <linux/slab.h>  // kfree, kmalloc
+#include <linux/vmalloc.h>  // vfree, vmalloc
 
 #include <../arch/x86/include/asm/desc.h>
 


### PR DESCRIPTION
Hi! Surprisingly for my context (Linux 6.2, Ubuntu 22.04) it does not compile without this include, so I propose adding it. Thanks!