### PR TITLE
Clarify import error message

### DIFF
--- a/revizor.py
+++ b/revizor.py
@@ -8,8 +8,13 @@ SPDX-License-Identifier: MIT
 
 try:
     from src.cli import main
-except ImportError:
-    from revizor.cli import main
+except ImportError as orig_import_error:
+    try:
+        from revizor.cli import main
+    except ImportError:
+        print("Unable to import main from src.cli.")
+        print(f"Issue during import of src.cli: `{orig_import_error}`")
+        exit(1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi!

I stumbled into a quite misleading situation. When I do not have `elftools` installed, the error message returned by Revizor is:

```
Traceback (most recent call last):
  File "/home/user/gits/olek-sca-fuzzer/revizor.py", line 12, in <module>
    from revizor.cli import main
  File "/home/user/gits/olek-sca-fuzzer/revizor.py", line 12, in <module>
    from revizor.cli import main
ModuleNotFoundError: No module named 'revizor.cli'; 'revizor' is not a package
```
Which is not descriptive of the underlying problem.

The proposed fix will give such an error message:
```
Unable to import main from src.cli.
Issue during import of src.cli: `No module named 'elftools'`
```
Feel free to edit the error message.

Thanks!