### PR TITLE
generator: add template-based fuzzing mode

### DIFF
--- a/src/asm_parser.py
+++ b/src/asm_parser.py
@@ -41,6 +41,7 @@ class AsmParserGeneric(AsmParser):
 
     def __init__(self, generator: Generator) -> None:
         self.generator = generator
+        self.generator.asm_parser = self
         self.target_desc = generator.target_desc
         self.instruction_map = self._create_instruction_spec_map()
 

--- a/src/interfaces.py
+++ b/src/interfaces.py
@@ -403,6 +403,7 @@ class Instruction:
     next: Optional[Instruction] = None
     previous: Optional[Instruction] = None
     is_instrumentation: bool
+    is_from_template: bool = False
     section_offset: int = 0
     section_id: int = 0
 
@@ -667,7 +668,7 @@ class Function:
     def __init__(self, name: str, owner: Actor):
         self.name = name
         self.owner = owner
-        self.exit = BasicBlock(f".exit_{name.lstrip('.function_')}")
+        self.exit = BasicBlock(f".exit_{name.removeprefix('.function_')}")
         self._all_bb = []
 
     def __len__(self):
@@ -847,6 +848,7 @@ class AsmParser(ABC):
 class Generator(ABC):
     instruction_set: InstructionSetAbstract
     target_desc: TargetDesc
+    asm_parser: AsmParser
     _state: int = 0
 
     def __init__(self, instruction_set: InstructionSetAbstract, seed: int):
@@ -872,7 +874,15 @@ class Generator(ABC):
     @abstractmethod
     def create_test_case(self, path: str, disable_assembler: bool = False) -> TestCase:
         """
-        Create a simple test case with a single BB
+        Generate a random test case base on the config options.
+        Run instrumentation passes and print the result into a file
+        """
+        pass
+
+    @abstractmethod
+    def create_test_case_from_template(self, template: str) -> TestCase:
+        """
+        Generate a test case based on a template by expanding RANDOM_* macros.
         Run instrumentation passes and print the result into a file
         """
         pass

--- a/src/x86/x86_asm_parser.py
+++ b/src/x86/x86_asm_parser.py
@@ -221,7 +221,7 @@ class X86AsmParser(AsmParserGeneric):
         with open(asm_file, "r") as f:
             with open(patched_asm_file, "w") as patched:
                 for line in f:
-                    line = line.strip()
+                    line = line.strip().lower()
                     if line.startswith(".macro.measurement_start:"):
                         has_measurement_start = True
                     elif line.startswith(".macro.measurement_end:"):
@@ -256,6 +256,7 @@ class X86AsmParser(AsmParserGeneric):
         with open(patched_asm_file, "r") as f:
             with open(patched_asm_file + ".tmp", "w") as patched:
                 for line in f:
+                    line = line.lower()
                     if line.startswith(".macro") and "nop" not in line:
                         patched.write(line[:-1] + macro_placeholder + "\n")
                     else:
@@ -267,6 +268,7 @@ class X86AsmParser(AsmParserGeneric):
             with open(patched_asm_file, "r") as f:
                 with open(patched_asm_file + ".tmp", "w") as patched:
                     for line in f:
+                        line = line.lower()
                         patched.write(line)
                         if line.startswith(main_function_label):
                             patched.write(".macro.measurement_start:" + macro_placeholder + "\n")
@@ -278,6 +280,7 @@ class X86AsmParser(AsmParserGeneric):
                 with open(patched_asm_file + ".tmp", "w") as patched:
                     prev_line = ""
                     for line in f:
+                        line = line.lower()
                         if line.startswith(".test_case_exit:"):
                             if prev_line.startswith(".section"):
                                 patched.write(".function_end:\n")

--- a/src/x86/x86_asm_parser.py
+++ b/src/x86/x86_asm_parser.py
@@ -222,9 +222,9 @@ class X86AsmParser(AsmParserGeneric):
             with open(patched_asm_file, "w") as patched:
                 for line in f:
                     line = line.strip().lower()
-                    if line.startswith(".macro.measurement_start:"):
+                    if line.startswith(".macro.measurement_start"):
                         has_measurement_start = True
-                    elif line.startswith(".macro.measurement_end:"):
+                    elif line.startswith(".macro.measurement_end"):
                         has_measurement_end = True
 
                     if not enter_found:

--- a/src/x86/x86_executor.py
+++ b/src/x86/x86_executor.py
@@ -201,6 +201,11 @@ class X86Executor(Executor):
     def __write_test_case(self, test_case: TestCase):
         actors = sorted(test_case.actors.values(), key=lambda a: (a.id_))
 
+        # sanity check
+        for symbol in test_case.symbol_table:
+            if symbol.type_ < 0:
+                self.LOG.error("attempt to use template as a test case")
+
         with open('/sys/x86_executor/test_case', 'wb') as f:
             # header
             f.write((len(actors)).to_bytes(8, byteorder='little'))  # n_actors

--- a/src/x86/x86_fuzzer.py
+++ b/src/x86/x86_fuzzer.py
@@ -62,13 +62,13 @@ class X86Fuzzer(FuzzerGeneric):
         super()._adjust_config(existing_test_case)
         update_instruction_list()
 
-    def start(self,
-              num_test_cases: int,
-              num_inputs: int,
-              timeout: int,
-              nonstop: bool = False) -> bool:
+    def _start(self,
+               num_test_cases: int,
+               num_inputs: int,
+               timeout: int,
+               nonstop: bool = False) -> bool:
         check_instruction_list(self.instruction_set)
-        return super().start(num_test_cases, num_inputs, timeout, nonstop)
+        return super()._start(num_test_cases, num_inputs, timeout, nonstop)
 
     def filter(self, test_case: TestCase, inputs: List[Input]) -> bool:
         """ This function implements a multi-stage algorithm that gradually filters out
@@ -129,13 +129,13 @@ class X86ArchitecturalFuzzer(ArchitecturalFuzzer):
         super()._adjust_config(existing_test_case)
         update_instruction_list()
 
-    def start(self,
-              num_test_cases: int,
-              num_inputs: int,
-              timeout: int,
-              nonstop: bool = False) -> bool:
+    def _start(self,
+               num_test_cases: int,
+               num_inputs: int,
+               timeout: int,
+               nonstop: bool = False) -> bool:
         check_instruction_list(self.instruction_set)
-        return super().start(num_test_cases, num_inputs, timeout, nonstop)
+        return super()._start(num_test_cases, num_inputs, timeout, nonstop)
 
 
 class X86ArchDiffFuzzer(FuzzerGeneric):
@@ -145,13 +145,13 @@ class X86ArchDiffFuzzer(FuzzerGeneric):
         super()._adjust_config(existing_test_case)
         update_instruction_list()
 
-    def start(self,
-              num_test_cases: int,
-              num_inputs: int,
-              timeout: int,
-              nonstop: bool = False) -> bool:
+    def _start(self,
+               num_test_cases: int,
+               num_inputs: int,
+               timeout: int,
+               nonstop: bool = False) -> bool:
         check_instruction_list(self.instruction_set)
-        return super().start(num_test_cases, num_inputs, timeout, nonstop)
+        return super()._start(num_test_cases, num_inputs, timeout, nonstop)
 
     def get_arch_traces(self, inputs) -> List[List[int]]:
         htraces: List[List[int]] = [

--- a/src/x86/x86_target_desc.py
+++ b/src/x86/x86_target_desc.py
@@ -135,6 +135,12 @@ class X86TargetDesc(TargetDesc):
     # FIXME: macro IDs should not be hardcoded but rather received from the executor
     # or at least we need a test that will check that the IDs match
     macro_specs = {
+        # macros with negative IDs are used for generation
+        # and are not supposed to reach the final binary
+        "random_instructions":
+            MacroSpec(-1, "random_instructions", ("int", "int", "", "")),
+
+        # macros with positive IDs are used for execution and can be interpreted by executor/model
         "function":
             MacroSpec(0, "function", ("", "", "", "")),
         "measurement_start":


### PR DESCRIPTION
The PR introduces a new fuzzing mode (`tfuzz`) that expands randomization macros and creates new test cases based on a template.

### Minimal example

Usage:
```
./revizor.py tfuzz -s base.json -c conf.yaml -t template.asm -i 10 -n 10
```

Contents of the template:
```
.intel_syntax noprefix
.test_case_enter:

.section .data.main
.function_start:
    .macro.random_instructions.64.32:
.test_case_exit:
```


