### PR TITLE
x86/executor: add int3 after ret to please objtool

### DIFF
--- a/src/x86/executor/code_loader.c
+++ b/src/x86/executor/code_loader.c
@@ -356,6 +356,7 @@ static inline void epilogue(void)
         // return 0
         "mov rax, 0\n"
         "ret\n"
+        "int3\n" // Silences objtool warnings about no int3 after ret
     );
 }
 
@@ -388,6 +389,7 @@ static inline void epilogue_dbg_gpr(void)
         // return 0
         "mov rax, 0\n"
         "ret\n"
+        "int3\n" // Silences objtool warnings about no int3 after ret
     );
 }
 // clang-format on

--- a/src/x86/executor/hw_features/fault_handler.c
+++ b/src/x86/executor/hw_features/fault_handler.c
@@ -177,6 +177,7 @@ __attribute__((unused)) void nmi_handler_wrapper(void)
                  "pop %%rbx\n"
                  "mov $0, %%rax\n"
                  "ret\n"
+                 "int3\n" // Silences objtool warnings about no int3 after ret
                  : [rsp_save] "=m"(pre_bubble_rsp)
                  :);
 }
@@ -267,7 +268,9 @@ __attribute__((unused)) void fallback_handler_wrapper(void)
 
     // return 1 to indicate an unhandled fault
     asm_volatile_intel("mov rax, 1\n"
-                       "ret\n");
+                       "ret\n"
+                       "int3\n" // Silences objtool warnings about no int3 after ret
+                       );
 }
 
 __attribute__((unused)) void bubble_handler_wrapper(void)
@@ -355,6 +358,7 @@ __attribute__((unused)) void bubble_handler_wrapper(void)
 
                  "mov $1, %%rax\n"
                  "ret\n"
+                 "int3\n" // Silences objtool warnings about no int3 after ret
                  : [rsp_save] "=m"(pre_bubble_rsp)
                  :);
 }

--- a/src/x86/executor/measurement.c
+++ b/src/x86/executor/measurement.c
@@ -229,6 +229,7 @@ __attribute__((unused)) void unsafe_bubble_wrapper(void)
                  "mov %[err], %%rax\n"
 
                  "ret\n"
+                 "int3\n" // Silences objtool warnings about no int3 after ret
                  : [rsp_save] "=m"(pre_bubble_rsp), [err] "+a"(err)
                  :);
     // Unreachable


### PR DESCRIPTION
Hi there!
This removes the warnings from objtool:

```
/path/to/repo/src/x86/executor/x86_executor.o: warning: objtool: nmi_handler_wrapper+0x5f: missing int3 after ret
/path/to/repo/src/x86/executor/x86_executor.o: warning: objtool: fallback_handler_wrapper+0xcb9: missing int3 after ret
/path/to/repo/src/x86/executor/x86_executor.o: warning: objtool: bubble_handler_wrapper+0xcc7: missing int3 after ret
/path/to/repo/src/x86/executor/x86_executor.o: warning: objtool: main_segment_template+0x305: missing int3 after ret
/path/to/repo/src/x86/executor/x86_executor.o: warning: objtool: main_segment_template_dbg_gpr+0x2c9: missing int3 after ret
/path/to/repo/src/x86/executor/x86_executor.o: warning: objtool: unsafe_bubble_wrapper+0x66: missing int3 after ret
```
We must also clarify the potential microarchitectural implications if any.
Thanks!