### PR TITLE
arm64: add COND model

### DIFF
--- a/src/arm64/tests/unit_model.py
+++ b/src/arm64/tests/unit_model.py
@@ -241,3 +241,123 @@ class ARMModelTest(unittest.TestCase):
                 code_base + 4, mem_base, code_base + 8, code_base + 12, code_base + 16, mem_base + 2
             ]))
         self.assertEqual(ctraces, [expected_trace])
+
+    def test_cond_decode_bcond(self):
+        '''test decoding of b.cond instructions'''
+        def test(instruction: int, flags: str, expect_target: int, expect_will_jump: bool):
+            flags_int = 0
+            if 'Z' in flags:
+                flags_int |= arm64_model.FLAG_Z
+            if 'C' in flags:
+                flags_int |= arm64_model.FLAG_C
+            if 'V' in flags:
+                flags_int |= arm64_model.FLAG_V
+            if 'N' in flags:
+                flags_int |= arm64_model.FLAG_N
+            instruction_bytes = instruction.to_bytes(4, byteorder='little')
+            self.assertEqual(
+                arm64_model.ARM64UnicornCond.decode(None, instruction_bytes, flags_int),
+                (expect_target, expect_will_jump)
+            )
+        # test b.eq
+        test(0x54000020, 'CVN', 1, False)
+        test(0x54000020, 'Z', 1, True)
+        test(0x54007d20, 'Z', 1001, True)
+        test(0x547a1220, 'Z', 250001, True)
+        test(0x5485ee00, 'Z', -250000, True)
+        # b.ne
+        test(0x54000021, 'Z', 1, False)
+        test(0x54000021, '', 1, True)
+        # b.cs
+        test(0x54000022, '', 1, False)
+        test(0x54000022, 'C', 1, True)
+        # b.cc
+        test(0x54000023, 'C', 1, False)
+        test(0x54000023, '', 1, True)
+        # b.mi
+        test(0x54000024, '', 1, False)
+        test(0x54000024, 'N', 1, True)
+        # b.pl
+        test(0x54000025, 'N', 1, False)
+        test(0x54000025, '', 1, True)
+        # b.vs
+        test(0x54000026, '', 1, False)
+        test(0x54000026, 'V', 1, True)
+        # b.vc
+        test(0x54000027, 'V', 1, False)
+        test(0x54000027, '', 1, True)
+        # b.hi
+        test(0x54000028, 'C', 1, True)
+        test(0x54000028, '', 1, False)
+        test(0x54000028, 'CZ', 1, False)
+        # b.ls
+        test(0x54000029, 'C', 1, False)
+        test(0x54000029, '', 1, True)
+        test(0x54000029, 'CZ', 1, True)
+        # b.ge
+        test(0x5400002a, 'N', 1, False)
+        test(0x5400002a, 'NV', 1, True)
+        # b.lt
+        test(0x5400002b, 'N', 1, True)
+        test(0x5400002b, 'NV', 1, False)
+        # b.gt
+        test(0x5400002c, 'NV', 1, True)
+        test(0x5400002c, 'ZNV', 1, False)
+        test(0x5400002c, 'N', 1, False)
+        # b.le
+        test(0x5400002d, 'NV', 1, False)
+        test(0x5400002d, 'ZNV', 1, True)
+        test(0x5400002d, 'N', 1, True)
+        # b.al
+        test(0x5400002e, '', 1, True)
+        test(0x5400002e, 'CVNZ', 1, True)
+        # b.nv
+        test(0x5400002f, '', 1, False)
+        test(0x5400002f, 'CVNZ', 1, False)
+
+    def test_cond_decode_tbz_cbz(self):
+        '''test decoding of tbz/tbnz/cbz/cbnz'''
+        regs = [0] * 31
+        def read_reg(which: int) -> int:
+            if ucc.UC_ARM64_REG_X0 <= which <= ucc.UC_ARM64_REG_X28:
+                return regs[which - ucc.UC_ARM64_REG_X0]
+            if ucc.UC_ARM64_REG_X29 <= which <= ucc.UC_ARM64_REG_X30:
+                return regs[30 + which - ucc.UC_ARM64_REG_X30]
+            self.fail('bad register')
+        def test(instruction: int, expect_target: int, expect_will_jump: bool):
+            instruction_bytes = instruction.to_bytes(4, byteorder='little')
+            self.assertEqual(
+                arm64_model.ARM64UnicornCond.decode(read_reg, instruction_bytes, 0),
+                (expect_target, expect_will_jump)
+            )
+        regs[30] = 1
+        # cbz
+        test(0xb4000020, 1, True)
+        test(0xb430d420, 100001, True)
+        test(0xb4ffffe0, -1, True)
+        test(0xb400003e, 1, False)
+        # cbnz
+        test(0xb5000020, 1, False)
+        test(0xb500003e, 1, True)
+        regs[0] = 0xfacecafe << 32
+        test(0xb4000020, 1, False)
+        # 32-bit cbz
+        test(0x34000020, 1, True)
+        test(0x35000020, 1, False)
+
+        regs[0] = 1 << 20 | 1 << 61
+        # tbz
+        test(0x36000020, 1, True)
+        test(0x36027120, 5001, True)
+        test(0x3607ffe0, -1, True)
+        test(0x36a00020, 1, False)
+        test(0xb6000020, 1, True)
+        test(0xb6e80020, 1, False)
+        # tbnz
+        test(0x37000020, 1, False)
+        test(0x37a00020, 1, True)
+        test(0xb7000020, 1, False)
+        test(0xb7e80020, 1, True)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/factory.py
+++ b/src/factory.py
@@ -111,7 +111,11 @@ def get_model(bases: Tuple[int, int]) -> interfaces.Model:
 
         model_instance.taint_tracker_cls = x86_model.X86TaintTracker
     elif CONF.instruction_set == 'arm64':
-        if "seq" in CONF.contract_execution_clause:
+        if "cond" in CONF.contract_execution_clause and "bpas" in CONF.contract_execution_clause:
+            model_instance = arm64_model.ARM64UnicornCondBpas(bases[0], bases[1])
+        elif "cond" in CONF.contract_execution_clause:
+            model_instance = arm64_model.ARM64UnicornCond(bases[0], bases[1])
+        elif "seq" in CONF.contract_execution_clause:
             model_instance = arm64_model.ARM64UnicornSeq(bases[0], bases[1])
         elif "bpas" in CONF.contract_execution_clause:
             model_instance = arm64_model.ARM64UnicornBpas(bases[0], bases[1])


### PR DESCRIPTION
This PR implements the "cond" execution model for the ARM64 architecture.
I've based it closely on the x86_64 implementation and it seems to prevent violations in my tests with the gem5 CPU simulator but perhaps someone with actual ARM hardware should try it out...