### PR TITLE
model: added tracer to track cache line granularity accesses

### DIFF
--- a/src/factory.py
+++ b/src/factory.py
@@ -29,6 +29,7 @@ TRACERS: Dict[str, Type[model.UnicornTracer]] = {
     "ctr": model.CTRTracer,
     "arch": model.ArchTracer,
     "gpr": model.GPRTracer,
+    "tct": model.TruncatedCTTracer,
 }
 
 X86_SIMPLE_EXECUTION_CLAUSES: Dict[str, Type[x86_model.UnicornModel]] = {

--- a/src/model.py
+++ b/src/model.py
@@ -210,6 +210,20 @@ class CTTracer(PCTracer):
         super(CTTracer, self).observe_mem_access(access, address, size, value, model)
 
 
+class TruncatedCTTracer(UnicornTracer):
+    """
+    Observe address of the memory access and of the program counter at cache line granularity.
+    """
+
+    def observe_mem_access(self, access, address, size, value, model):
+        self.add_mem_address_to_trace((address >> 6) << 6, model)
+        super(TruncatedCTTracer, self).observe_mem_access(access, address, size, value, model)
+
+    def observe_instruction(self, address: int, size: int, model):
+        self.add_pc_to_trace((address >> 6) << 6, model)
+        super(TruncatedCTTracer, self).observe_instruction(address, size, model)
+
+
 class CTNonSpecStoreTracer(PCTracer):
     """
     Observe address of memory access only if not in speculation or it is a read.


### PR DESCRIPTION
The default constant-time tracer tracks full addresses. This PR adds a new tracer that tracks addresses at cache line granularity.