### PR TITLE
config: [fix] get automatic executor vendor

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -129,7 +129,7 @@ class Conf:
 
     # ==============================================================================================
     # Executor
-    executor: str = ''
+    executor: str = x86_config.try_get_cpu_vendor()
     """ executor: executor type """
     executor_mode: str = 'P+P'
     """ executor_mode: hardware trace collection mode """


### PR DESCRIPTION
Makes #85 work. Else the automatically found executor will always be overwritten with an empty string.

Thanks!
Flavien