### PR TITLE
Update fault_handler.c to fix an UB issue

### DIFF
--- a/src/x86/executor/hw_features/fault_handler.c
+++ b/src/x86/executor/hw_features/fault_handler.c
@@ -75,7 +75,7 @@ void idt_set_custom_handlers(gate_desc *idt, struct desc_ptr *idtr, void *main_h
             continue;
         }
 
-        if (BIT_CHECK(handled_faults, idx)) {
+        if (idx < 32 && BIT_CHECK(handled_faults, idx)) {
             set_intr_gate_default(idt, idx, main_handler);
             continue;
         }


### PR DESCRIPTION
Fixes
```
UBSAN: shift-out-of-bounds in /home/user/gits/sca-fuzzer/src/x86/executor/hw_features/fault_handler.c:78:13
shift exponent 64 is too large for 64-bit type 'long long unsigned int'                                    
```

I think from 32 on the mask is not relevant since the mask is defined as `extern uint32_t handled_faults` in `fault_handler.h`. You may change the comparison to `idx < 64` probably if you prefer.

Thanks!