### PR TITLE
Update cli.py to harmonize flags of tfuzz and minimize

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -142,8 +142,8 @@ def main() -> int:
     # Postprocessing interface
     parser_mini = subparsers.add_parser('minimize', add_help=True)
     parser_mini.add_argument(
-        '--infile',
-        '-i',
+        '--genfile',
+        '-g',
         type=str,
         required=True,
     )
@@ -155,7 +155,7 @@ def main() -> int:
     )
     parser_mini.add_argument("-c", "--config", type=str, required=False)
     parser_mini.add_argument(
-        "-n",
+        "-i",
         "--num-inputs",
         type=int,
         default=100,


### PR DESCRIPTION
Hi!
I found it quite confusing that the `-i` of `minimize` does not correspond to the `-i` of `tfuzz` but to its `-n`.
This PR might imply some changes in the docs or some higher-level scripts, potentially.

Thanks!
Flavien