### PR TITLE
WSL2 Support (pre-release)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,16 +72,24 @@ make install
 ### 3. a) WSL 2 support:
 Must compile Revizor from source.
 
-Must compile kernel from source. WSL2 kernel does support PFC MSR passthrough, but not in the kernel shipped with every WSL2 install. Compiling from source enables these settings.
+Must compile WSL2 kernel from source. 
+- WSL2 kernel source does support PFC MSR passthrough, but not in the kernel shipped with every WSL2 install. Compiling from source enables these settings.
+- WSL1 is not supported (No PFC passthrough) 
 
-Install and launch wsl:
+Install and launch WSL2:
+```
 wsl --install
 wsl --update
 wsl
+```
 
-Kernel:
-Download kernel: https://github.com/microsoft/WSL2-Linux-Kernel;
-Prereqs: sudo apt install build-essential flex bison dwarves libssl-dev libelf-dev bc;
+Download kernel: https://github.com/microsoft/WSL2-Linux-Kernel
+
+Prerequiste: 
+```bash
+sudo apt install build-essential flex bison dwarves libssl-dev libelf-dev bc
+```
+
 Build, compile, and load kernel: 
   ```bash
   cd ./WSL2-Linux-Kernel
@@ -91,19 +99,19 @@ Build, compile, and load kernel:
   - Do not use x86_64!
 
   In Windows:
-  Copy out the kernel binary (bzImage) from the WSL2 network drive to a native Windows (i.e. NTFS) partition
-  Navigate to C:\Users\$USER
-  Create file .wslconfig (i.e. C:\Users\$USER\.wslconfig), fill it with this:
-  ```conf
-  [wsl2]
-  kernel=C:\\Users\\$USER\\$PATH_TO_IMAGE_DIR\\bzImage
-  ```
-  - File will not pre-exist. You must create it.
-  - Must use 2 backslashes. Must point to image in Windows partition.
-  Run in Powershell/Command Prompt: `wsl --shutdown`
+  - Copy out the kernel binary (bzImage) from the WSL2 network drive to a native Windows (i.e. NTFS) partition
+  - Navigate to `C:\Users\$USER`
+  - Create file .wslconfig (i.e. `C:\Users\$USER\.wslconfig`), fill it with this:
+    ```conf
+    [wsl2]
+    kernel=C:\\Users\\$USER\\$PATH_TO_IMAGE_DIR\\bzImage
+    ```
+    - File will not pre-exist. You must create it.
+    - Must use 2 backslashes. Must point to image in Windows partition.
+  - Run in Powershell/Command Prompt: `wsl --shutdown`
     - Ensure no other instances of WSL are running on your system.
-  Wait [8 seconds](https://learn.microsoft.com/en-us/windows/wsl/wsl-config#the-8-second-rule-for-configuration-changes)
-  Start WSL. Check kernel with `uname -r`. If it loads correctly, you should have successfully installed your custom kernel!
+  - Wait [8 seconds](https://learn.microsoft.com/en-us/windows/wsl/wsl-config#the-8-second-rule-for-configuration-changes).
+  - Start WSL. Check kernel with `uname -r`. If it loads correctly, you should have successfully installed your custom kernel!
 
 Install kernel headers & kernel modules support:
 ```bash

--- a/README.md
+++ b/README.md
@@ -41,12 +41,19 @@ source ~/venv-revizor/bin/activate
 pip install revizor-fuzzer
 ```
 
+Alternatively, install Revizor from sources:
+```bash
+# run from the project root directory
+pip install build
+make install
+```
+
 ### 3. Install Revizor Executor (kernel module)
 
 Then build and install the kernel module:
 
 ```bash
-# building a kernel module require kernel headers
+# building a kernel module require kernel headers (skip for WSL; see below)
 sudo apt-get install linux-headers-$(uname -r)
 # required for cpuid.h
 sudo apt-get install linux-headers-generic
@@ -61,6 +68,52 @@ make clean
 make
 make install
 ```
+
+### 3. a) WSL 2 support:
+Must compile Revizor from source.
+
+Must compile kernel from source. WSL2 kernel does support PFC MSR passthrough, but not in the kernel shipped with every WSL2 install. Compiling from source enables these settings.
+
+Install and launch wsl:
+wsl --install
+wsl --update
+wsl
+
+Kernel:
+Download kernel: https://github.com/microsoft/WSL2-Linux-Kernel;
+Prereqs: sudo apt install build-essential flex bison dwarves libssl-dev libelf-dev bc;
+Build, compile, and load kernel: 
+  ```bash
+  cd ./WSL2-Linux-Kernel
+  make -j $(expr $(nproc) - 1) KCONFIG_CONFIG=Microsoft/config-wsl # Very long compute time
+  ```
+  Built kernel for x86 located at: WSL2-Linux-Kernel/arch/x86/boot/bzImage
+  - Do not use x86_64!
+
+  In Windows:
+  Copy out the kernel binary (bzImage) from the WSL2 network drive to a native Windows (i.e. NTFS) partition
+  Navigate to C:\Users\$USER
+  Create file .wslconfig (i.e. C:\Users\$USER\.wslconfig), fill it with this:
+  ```conf
+  [wsl2]
+  kernel=C:\\Users\\$USER\\$PATH_TO_IMAGE_DIR\\bzImage
+  ```
+  - File will not pre-exist. You must create it.
+  - Must use 2 backslashes. Must point to image in Windows partition.
+  Run in Powershell/Command Prompt: `wsl --shutdown`
+    - Ensure no other instances of WSL are running on your system.
+  Wait [8 seconds](https://learn.microsoft.com/en-us/windows/wsl/wsl-config#the-8-second-rule-for-configuration-changes)
+  Start WSL. Check kernel with `uname -r`. If it loads correctly, you should have successfully installed your custom kernel!
+
+Install kernel headers & kernel modules support:
+```bash
+cd ./WSL2-Linux-Kernel;
+make headers_install; # Default INSTALL_HDR_PATH=/usr
+sudo make modules_install; # Installed to /lib/modules
+```
+
+Should now be able to build the executor as normal, and should also be able to download ISA spec as normal.
+Remember to launch revizor with `python3 ./revizor.py` instead of `rvzr`!
 
 ### 4. Download ISA spec
 

--- a/src/x86/executor/measurement.c
+++ b/src/x86/executor/measurement.c
@@ -26,6 +26,8 @@
 #include "vmx.h"
 #include "svm.h"
 
+#include <../arch/x86/include/asm/desc.h>
+
 measurement_t *measurements = NULL; // global
 
 int unsafe_bubble(void);


### PR DESCRIPTION
Issue: Cannot load kernel modules into standard WSL2 kernel (or generate kernel headers)
Solution: Enable module support, get headers directly from kernel source

TODOs:
- Only tested on main branch; Test again using pre-release as base branch.
- Test that the change in measurement.c does not break linux build chain before merging!

Solved with:
https://unix.stackexchange.com/questions/594470/wsl-2-does-not-have-lib-modules
https://learn.microsoft.com/en-us/answers/questions/1426263/how-to-enable-modules-in-wsl2
https://github.com/microsoft/WSL/issues/11557
Reference:
https://askubuntu.com/questions/1350457/installing-linux-headers-standard-on-ubuntu-20-04-wsl2
https://learn.microsoft.com/en-us/windows/wsl/wsl-config#wslconfig