### PR TITLE
cli: [fix] Invalid argument in CLI tfuzz mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ src/x86/executor/measurement.o.ur-safe
 dbg/
 site
 dist/
+generated
+generated.asm

--- a/src/cli.py
+++ b/src/cli.py
@@ -113,7 +113,7 @@ def main() -> int:
     parser_tfuzz.add_argument(
         '--nonstop', action='store_true', help="Don't stop after detecting an unexpected result")
     parser_tfuzz.add_argument(
-        '--enable-store-violations',
+        '--save-violations',
         type=arg2bool,
         default=True,
         help="If set, store all detected violations in working directory.",


### PR DESCRIPTION
Will crash on tfuzz run otherwise.

Adding the 2 entries to gitignore will allow easy git changes whilst runs are active.

Side note: Using "CTRL+C" to cancel the run halfway will now cause it to spit out a "bug" violation for the canceled run (assuming this is to detect archfuzz bugs). Be careful to distinguish between actual architectural bugs and the false positives that are just testing artifacts.