### PR TITLE
cli: [fix] Invalid argument in CLI tfuzz mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ src/x86/*.json
 *.code-workspace
 *.o
 src/generated.asm
+generated.asm
+generated
 src/x86/executor/.cache.mk
 src/x86/executor/measurement.o.ur-safe
 dbg/

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -77,7 +77,7 @@ The following command-line arguments are supported in `analyse` mode:
                         The template to use for generating test cases
   --timeout TIMEOUT     Run fuzzing with a time limit [seconds]. No timeout when set to zero.
   --nonstop             Don't stop after detecting an unexpected result
-  --enable-store-violations ENABLE_STORE_VIOLATIONS
+  --save-violations SAVE_VIOLATIONS
                         If set, store all detected violations in working directory.
 ```
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -136,7 +136,7 @@ def main() -> int:
     parser_tfuzz.add_argument(
         '--nonstop', action='store_true', help="Don't stop after detecting an unexpected result")
     parser_tfuzz.add_argument(
-        '--enable-store-violations',
+        '--save-violations',
         type=arg2bool,
         default=True,
         help="If set, store all detected violations in working directory.",


### PR DESCRIPTION
Will crash on tfuzz run otherwise.

Adding the 2 entries to gitignore will allow easy git changes whilst runs are active.

Side note: Using "CTRL+C" to cancel the run halfway will now cause it to spit out a "bug" violation for the canceled run (assuming this is to detect archfuzz bugs). Be careful to distinguish between actual architectural bugs and the false positives that are just testing artifacts.