### PR TITLE
Apply clang-tidy to Dynamorio model headers

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -60,7 +60,7 @@ sudo apt-get install cmake g++ g++-multilib doxygen git zlib1g-dev libunwind-dev
 make -C rvzr/model_dynamorio
 
 # check installation
-~/.local/dynamorio/drrun -c ~/.local/dynamorio/libdr_model.so --list-obs-clauses -- ls
+~/.local/dynamorio/drrun -c ~/.local/dynamorio/libdr_model.so --list-tracers -- ls
 # expected output:
 #   ct
 #   ...

--- a/rvzr/model_dynamorio/Makefile
+++ b/rvzr/model_dynamorio/Makefile
@@ -6,7 +6,7 @@ model_path := $(HOME)/.local/dynamorio/model/
 
 release := 11.2.0
 
-.PHONY: all download_dr backend adapter
+.PHONY: all download_dr backend adapter clean-backend clean-adapter clean
 
 all: download_dr backend adapter
 
@@ -24,7 +24,7 @@ $(dr_path)/drrun:
 
 backend:
 	mkdir -p $(current_dir)/backend/build
-	cd $(current_dir)/backend/build && cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DDynamoRIO_DIR=$(dr_path)/DynamoRIO-Linux-$(release)/cmake --config Debug  $(current_dir)/backend
+	cd $(current_dir)/backend/build && cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DDynamoRIO_DIR=$(dr_path)/DynamoRIO-Linux-$(release)/cmake -D CMAKE_BUILD_TYPE=Debug  $(current_dir)/backend
 	make -C $(current_dir)/backend/build
 	cp $(current_dir)/backend/build/libdr_model.so $(dr_path)
 
@@ -34,8 +34,13 @@ adapter:
 	make -C $(current_dir)/adapter/build
 	make -C $(current_dir)/adapter/build install
 
+clean-backend:
+	rm -rf $(current_dir)/backend/build
 
+clean-adapter:
+	rm -rf $(current_dir)/adapter/build
 
+clean:  clean-backend clean-adapter
 
 # * build dr_model
 

--- a/rvzr/model_dynamorio/adapter/.clang-tidy
+++ b/rvzr/model_dynamorio/adapter/.clang-tidy
@@ -12,6 +12,7 @@ Checks: >
     -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
     -misc-include-cleaner,
     -cert-err33-c,
+    -llvm-header-guard, # Use pragma once instead of LLVM-style guards
 
 # Turn all the warnings from the checks above into errors.
 WarningsAsErrors: "*"

--- a/rvzr/model_dynamorio/backend/.clang-tidy
+++ b/rvzr/model_dynamorio/backend/.clang-tidy
@@ -8,6 +8,10 @@
 # - `cppcoreguidelines-pro-type-vararg`: Incompatible with the DR API, such as dr_printf
 # - `cppcoreguidelines-pro-type-union-access`: Incompatible with dr_mcontext_t
 # - `cppcoreguidelines-pro-type-cstyle-cast`: C-style casts are necessary for DR API
+# - `coreguidelines-non-private-member-variables-in-classes`: Accessors make code unreasonably verbose
+# - `cppcoreguidelines-non-private-member-variables-in-classes`: Alias of the above
+# - `llvm-header-guard`: Checks for "LLVM-style" include guards, we want to use #pragma once instead
+# - `modernize-use-using`: This style diverges from the rest of the code base
 Checks: >
     -*,
     bugprone-*,
@@ -26,6 +30,10 @@ Checks: >
     -cppcoreguidelines-pro-type-reinterpret-cast,
     -cppcoreguidelines-pro-type-cstyle-cast,
     -performance-no-int-to-ptr,
+    -misc-non-private-member-variables-in-classes,
+    -cppcoreguidelines-non-private-member-variables-in-classes,
+    -llvm-header-guard,
+    -modernize-use-using,
 
 # Turn all the warnings from the checks above into errors.
 WarningsAsErrors: "*"
@@ -38,4 +46,4 @@ CheckOptions:
     - key: readability-identifier-length.IgnoredParameterNames
       value: "pc|mc|bb|dc|it"
     - key: bugprone-easily-swappable-parameters.IgnoredParameterNames
-      value: '"";drcontext;wrapctx;;user_data;xflags'
+      value: '"";drcontext;wrapctx;;user_data;xflags;max_nesting_'

--- a/rvzr/model_dynamorio/backend/cli.cpp
+++ b/rvzr/model_dynamorio/backend/cli.cpp
@@ -20,8 +20,8 @@ using std::string;
 using dynamorio::droption::DROPTION_SCOPE_CLIENT;
 using dynamorio::droption::droption_t;
 
-bool validate_tracer(cli_args_t *parsed_args);
-bool validate_speculator(cli_args_t *parsed_args);
+static bool validate_tracer(cli_args_t *parsed_args);
+static bool validate_speculator(cli_args_t *parsed_args);
 
 static const int max_reasonable_nesting = 100;
 static const int max_reasonable_spec_window = 1000;

--- a/rvzr/model_dynamorio/backend/include/observables.hpp
+++ b/rvzr/model_dynamorio/backend/include/observables.hpp
@@ -11,7 +11,6 @@
 typedef uint64_t opcode_t;
 typedef uint64_t pc_t;
 
-
 /// @brief Structure describing observable information of an instruction
 typedef struct {
     uint64_t opcode;

--- a/rvzr/model_dynamorio/backend/include/speculator_abc.hpp
+++ b/rvzr/model_dynamorio/backend/include/speculator_abc.hpp
@@ -58,8 +58,8 @@ class SpeculatorABC
     // ---------------------------------------------------------------------------------------------
     // Public Methods
 
-    void enable(void);
-    void disable(void);
+    void enable();
+    void disable();
 
     /// @brief Rollback to the last checkpoint, thus undoing all speculative changes to the process
     ///        state.
@@ -78,7 +78,7 @@ class SpeculatorABC
     ///        nesting, speculation window, or other conditions).
     /// @param void
     /// @return true if speculation should be skipped, false otherwise
-    bool skip_speculation(void) const;
+    [[nodiscard]] bool skip_speculation() const;
 
     /// @brief Emulates speculation for the given instruction according to the target contract.
     ///        Each subclass implements a different contract, hence the implementation

--- a/rvzr/model_dynamorio/backend/include/speculators/cond.hpp
+++ b/rvzr/model_dynamorio/backend/include/speculators/cond.hpp
@@ -29,5 +29,5 @@ class SpeculatorCond : public SpeculatorABC
     /// @param dc The current DR context
     /// @return 0 if no speculation was triggered or no redirection is needed;
     ///         otherwise, the PC of the instruction to which the execution should be redirected
-    virtual pc_t handle_instruction(instr_obs_t instr, dr_mcontext_t *mc, void *dc);
+    pc_t handle_instruction(instr_obs_t instr, dr_mcontext_t *mc, void *dc) override;
 };

--- a/rvzr/model_dynamorio/backend/include/tracer_abc.hpp
+++ b/rvzr/model_dynamorio/backend/include/tracer_abc.hpp
@@ -22,7 +22,7 @@ using std::uint64_t;
 // =================================================================================================
 // Constants and Types
 // =================================================================================================
-enum trace_entry_type_t {
+enum class trace_entry_type_t : uint8_t {
     ENTRY_EOT = 0, // end of trace
     ENTRY_PC = 1,
     ENTRY_READ = 2,
@@ -31,13 +31,13 @@ enum trace_entry_type_t {
 };
 
 struct trace_entry_t {
-    uint64_t type; // see trace_entry_type_t
-    pc_t addr;     // pc for instructions; address for memory accesses
+    trace_entry_type_t type; // see trace_entry_type_t
+    pc_t addr;               // pc for instructions; address for memory accesses
     uint64_t size; // instruction size for instructions; memory access size for memory accesses
 };
 
 struct dbg_trace_entry_t {
-    uint64_t type; // always ENTRY_REG_DUMP
+    trace_entry_type_t type; // always ENTRY_REG_DUMP
     uint64_t xax;
     uint64_t xbx;
     uint64_t xcx;

--- a/rvzr/model_dynamorio/backend/include/util.hpp
+++ b/rvzr/model_dynamorio/backend/include/util.hpp
@@ -33,4 +33,3 @@ void reserve_register_checked(void *drcontext, instrlist_t *ilist, instr_t *wher
 /// @param reg The register to unreserve
 /// @return void
 void unreserve_register_checked(void *drcontext, instrlist_t *ilist, instr_t *where, reg_id_t reg);
-

--- a/rvzr/model_dynamorio/backend/tracer_abc.cpp
+++ b/rvzr/model_dynamorio/backend/tracer_abc.cpp
@@ -54,16 +54,17 @@ void print_traces(vector<trace_entry_t> *trace, bool enable_bin_output = false)
         if (enable_bin_output) {
             fwrite(&entry, sizeof(trace_entry_t), 1, stdout);
         } else {
-            fprintf(stdout, "%lx %lx %lx\n", entry.type, entry.addr, entry.size);
+            fprintf(stdout, "%lx %lx %lx\n", static_cast<uint64_t>(entry.type), entry.addr,
+                    entry.size);
         }
     }
 
     // Print a marker to indicate the end of the trace (EOT)
-    trace_entry_t eot = {ENTRY_EOT, 0, 0};
+    trace_entry_t eot = {trace_entry_type_t::ENTRY_EOT, 0, 0};
     if (enable_bin_output) {
         fwrite(&eot, sizeof(trace_entry_t), 1, stdout);
     } else {
-        fprintf(stdout, "%lx %lx %lx\n", eot.type, eot.addr, eot.size);
+        fprintf(stdout, "%lx %lx %lx\n", static_cast<uint64_t>(eot.type), eot.addr, eot.size);
     }
 }
 
@@ -85,11 +86,11 @@ void print_dbg_traces(vector<dbg_trace_entry_t> *dbg_trace, bool enable_bin_outp
     }
 
     // Print the end of trace marker
-    trace_entry_t eot = {ENTRY_EOT, 0, 0};
+    trace_entry_t eot = {trace_entry_type_t::ENTRY_EOT, 0, 0};
     if (enable_bin_output) {
         fwrite(&eot, sizeof(trace_entry_t), 1, stdout);
     } else {
-        fprintf(stdout, "%lx %lx %lx\n", eot.type, eot.addr, eot.size);
+        fprintf(stdout, "%lx %lx %lx\n", static_cast<uint64_t>(eot.type), eot.addr, eot.size);
     }
 }
 
@@ -146,7 +147,7 @@ void TracerABC::observe_instruction(instr_obs_t instr, dr_mcontext_t *mc)
     // In debug mode, store the register values and PC on the debug trace buffer
     if (enable_dbg_trace) {
         const dbg_trace_entry_t entry = {
-            .type = ENTRY_REG_DUMP,
+            .type = trace_entry_type_t::ENTRY_REG_DUMP,
             .xax = mc->xax,
             .xbx = mc->xbx,
             .xcx = mc->xcx,

--- a/rvzr/model_dynamorio/backend/tracers/ct.cpp
+++ b/rvzr/model_dynamorio/backend/tracers/ct.cpp
@@ -28,7 +28,7 @@ void TracerCT::observe_instruction(instr_obs_t instr, dr_mcontext_t *mc)
 
     // Create an new entry and push it on the trace buffer
     const trace_entry_t entry = {
-        .type = ENTRY_PC,
+        .type = trace_entry_type_t::ENTRY_PC,
         .addr = instr.pc,
         .size = 0,
     };
@@ -46,7 +46,7 @@ void TracerCT::observe_mem_access(bool is_write, void *address, uint64_t size)
 
     // Create an new entry and push it on the trace buffer
     const trace_entry_t entry = {
-        .type = (is_write) ? ENTRY_WRITE : ENTRY_READ,
+        .type = (is_write) ? trace_entry_type_t::ENTRY_WRITE : trace_entry_type_t::ENTRY_READ,
         .addr = reinterpret_cast<uint64_t>(address),
         .size = size,
     };

--- a/rvzr/model_dynamorio/backend/tracers/pc.cpp
+++ b/rvzr/model_dynamorio/backend/tracers/pc.cpp
@@ -28,7 +28,7 @@ void TracerPC::observe_instruction(instr_obs_t instr, dr_mcontext_t *mc)
 
     // Create an new entry and push it on the trace buffer
     const trace_entry_t entry = {
-        .type = ENTRY_PC,
+        .type = trace_entry_type_t::ENTRY_PC,
         .addr = instr.pc,
         .size = 0,
     };

--- a/rvzr/model_dynamorio/model.py
+++ b/rvzr/model_dynamorio/model.py
@@ -356,7 +356,7 @@ class _TraceReader:
 
     def _decode_next_entry_type(self, bin_traces: bytes, cursor: int) -> _TRACE_TYPE:
         """ Decode the entry type and return the type and the number of bytes consumed """
-        type_id = int.from_bytes(bin_traces[cursor:cursor + 8], byteorder="little")
+        type_id = int.from_bytes(bin_traces[cursor:cursor + 1], byteorder="little")
         if type_id not in _TRACE_ID_TO_NAME:
             raise ValueError(f"Unknown trace type ID: {type_id}")
         type_ = _TRACE_ID_TO_NAME[type_id]

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -67,12 +67,12 @@ function code_style_check() {
     echo "===== [DR] Code Style & Linting with clang-tidy ====="
     cd $SCRIPT_DIR/../rvzr/model_dynamorio || exit
     if [ -d "adapter/build" ]; then
-        find . -name "*.c" | grep -v "CMakeFiles"  | xargs clang-tidy --quiet --p adapter/build/ --config-file=adapter/.clang-tidy
+        find . -name "*.c" -or -name "*.h" | grep -v "CMakeFiles"  | xargs clang-tidy --quiet --p adapter/build/ --config-file=adapter/.clang-tidy
     else
         echo "[DR] No build directory for DR adapter found; skipping clang-tidy check"
     fi
     if [ -d "backend/build" ]; then
-        find . -name "*.cpp" | grep -v "CMakeFiles" | xargs clang-tidy --quiet --config-file=backend/.clang-tidy -p backend/build
+        find . -name "*.cpp" -or -name "*.hpp" | grep -v "CMakeFiles" | xargs clang-tidy --quiet --config-file=backend/.clang-tidy -p backend/build
     else
         echo "[DR] No build directory for DR backend found; skipping clang-tidy check"
     fi


### PR DESCRIPTION
This PR contains a couple minor improvements related to the current dynamorio model:

- `cmake` version >= 3.20 doesn't support `--config=Debug` anymore -- ported to new `cmake`
- added `make clean` to dynamorio Makefile
- fixed an outdated dynamorio flag in the quickstart doc
- clang-tidy now scans `.h`/`.hpp` files as well - the reported errors have been either fixed or added to the ignore-list