### PR TITLE
Add IND tracer for indirect calls, indirect branches and returns

### DIFF
--- a/rvzr/model_dynamorio/backend/dispatcher.cpp
+++ b/rvzr/model_dynamorio/backend/dispatcher.cpp
@@ -41,7 +41,7 @@ static pc_t instruction_dispatch(dr_mcontext_t *mc, void *dc, const Dispatcher *
                                  instr_obs_t instr)
 {
     dispatcher->logger->log_instruction(instr, mc, dispatcher->speculator->get_nesting_level());
-    dispatcher->tracer->observe_instruction(instr, mc);
+    dispatcher->tracer->observe_instruction(instr, mc, dc);
     const pc_t next_pc = dispatcher->speculator->handle_instruction(instr, mc, dc);
     return next_pc;
 }

--- a/rvzr/model_dynamorio/backend/factory.cpp
+++ b/rvzr/model_dynamorio/backend/factory.cpp
@@ -18,6 +18,7 @@
 #include "speculators/seq.hpp"
 #include "tracer_abc.hpp"
 #include "tracers/ct.hpp"
+#include "tracers/ind.hpp"
 #include "tracers/pc.hpp"
 
 using std::function;
@@ -39,6 +40,12 @@ const std::unordered_map<string, function<unique_ptr<TracerABC>(const string &, 
                             "pc",
                             [](const string &out_path, Logger &logger, bool print) {
                                 return std::make_unique<TracerPC>(out_path, logger, print);
+                            },
+                        },
+                        {
+                            "ind",
+                            [](const string &out_path, Logger &logger, bool print) {
+                                return std::make_unique<TracerInd>(out_path, logger, print);
                             },
                         }};
 

--- a/rvzr/model_dynamorio/backend/include/tracer_abc.hpp
+++ b/rvzr/model_dynamorio/backend/include/tracer_abc.hpp
@@ -55,11 +55,11 @@ class TracerABC
     ///        by the target contract.
     ///        Note: some subclasses may not record any information as the corresponding
     ///        contract may not require it. For such subclasses, this method should be a no-op.
-    /// @param opcode The opcode of the instruction
-    /// @param pc The program counter (address) of the instruction
+    /// @param instr the observed instruction
     /// @param mc The machine context of the instruction
+    /// @param dc The DR context of the instruction
     /// @return void
-    virtual void observe_instruction(instr_obs_t instr, dr_mcontext_t *mc);
+    virtual void observe_instruction(instr_obs_t instr, dr_mcontext_t *mc, void *dc);
 
     /// @brief Record per-memory access information on the trace (e.g., its address and value)
     ///        as defined by the target contract.

--- a/rvzr/model_dynamorio/backend/include/tracers/ct.hpp
+++ b/rvzr/model_dynamorio/backend/include/tracers/ct.hpp
@@ -19,11 +19,11 @@ class TracerCT : public TracerABC
     using TracerABC::TracerABC;
 
     /// @brief Record the PC of the executed instruction on the contract trace
-    /// @param opcode unused
-    /// @param pc The program counter of the executed instruction
+    /// @param instr the observed instruction
     /// @param mc unused
+    /// @param dc unused
     /// @return void
-    void observe_instruction(instr_obs_t instr, dr_mcontext_t *mc) override;
+    void observe_instruction(instr_obs_t instr, dr_mcontext_t *mc, void *dc) override;
 
     /// @brief Record the memory access
     /// @param type The type of the memory access (read or write)

--- a/rvzr/model_dynamorio/backend/include/tracers/ind.hpp
+++ b/rvzr/model_dynamorio/backend/include/tracers/ind.hpp
@@ -1,0 +1,28 @@
+///
+/// File: Header for the Indirect Call Tracer
+///
+// Copyright (C) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <dr_api.h> // NOLINT
+#include <dr_defines.h>
+
+#include "tracer_abc.hpp"
+
+/// @brief Indirect Tracer;
+/// This tracer collects target addresses of indirect calls, indirect branches and returns
+class TracerInd : public TracerABC
+{
+  public:
+    using TracerABC::TracerABC;
+
+    /// @brief Record the target of the executed indirect call (or branch or ret) on the contract
+    /// trace
+    /// @param instr the instruction being observed
+    /// @param mc the instructions's memory context
+    /// @param dc the instructions's DR context
+    /// @return void
+    void observe_instruction(instr_obs_t instr, dr_mcontext_t *mc, void *dc) override;
+};

--- a/rvzr/model_dynamorio/backend/include/tracers/pc.hpp
+++ b/rvzr/model_dynamorio/backend/include/tracers/pc.hpp
@@ -19,9 +19,9 @@ class TracerPC : public TracerABC
     using TracerABC::TracerABC;
 
     /// @brief Record the PC of the executed instruction on the contract trace
-    /// @param opcode unused
-    /// @param pc The program counter of the executed instruction
+    /// @param instr the observed instruction
     /// @param mc unused
+    /// @param dc unused
     /// @return void
-    void observe_instruction(instr_obs_t instr, dr_mcontext_t *mc) override;
+    void observe_instruction(instr_obs_t instr, dr_mcontext_t *mc, void *dc) override;
 };

--- a/rvzr/model_dynamorio/backend/include/types/trace.hpp
+++ b/rvzr/model_dynamorio/backend/include/types/trace.hpp
@@ -15,7 +15,8 @@ enum class trace_entry_type_t : uint8_t {
     ENTRY_PC = 1,
     ENTRY_READ = 2,
     ENTRY_WRITE = 3,
-    ENTRY_EXCEPTION = 4
+    ENTRY_EXCEPTION = 4,
+    ENTRY_IND = 5,
 };
 
 /// @brief Pretty-printer for trace_entry_type_t
@@ -32,6 +33,8 @@ static constexpr const char *to_string(const trace_entry_type_t &type)
         return "WRITE";
     case trace_entry_type_t::ENTRY_EXCEPTION:
         return "XCPT";
+    case trace_entry_type_t::ENTRY_IND:
+        return "IND";
     }
 
     return "UNKNOWN";
@@ -39,7 +42,7 @@ static constexpr const char *to_string(const trace_entry_type_t &type)
 
 /// @brief An entry of an observed trace
 struct trace_entry_t {
-    // pc for instructions; address for memory accesses
+    // pc for instructions; address for memory accesses; target for indirect calls
     uint64_t addr;
     // instruction size for instructions; memory access size for memory accesses
     uint32_t size;
@@ -72,6 +75,9 @@ struct trace_entry_t {
         case trace_entry_type_t::ENTRY_EXCEPTION:
             out << " faulty_addr: " << std::hex << addr;
             out << "  (sig: " << std::dec << size << ")";
+            break;
+        case trace_entry_type_t::ENTRY_IND:
+            out << "  --> target: " << std::hex << addr;
             break;
         }
 

--- a/rvzr/model_dynamorio/backend/tracer_abc.cpp
+++ b/rvzr/model_dynamorio/backend/tracer_abc.cpp
@@ -73,7 +73,7 @@ void TracerABC::tracing_finalize()
     tracing_finalized = true;
 }
 
-void TracerABC::observe_instruction(instr_obs_t /*instr*/, dr_mcontext_t * /*mc*/)
+void TracerABC::observe_instruction(instr_obs_t /*instr*/, dr_mcontext_t * /*mc*/, void * /*dc*/)
 {
     // The rest of the functionality - if any - is implemented by subclasses
 }

--- a/rvzr/model_dynamorio/backend/tracers/ct.cpp
+++ b/rvzr/model_dynamorio/backend/tracers/ct.cpp
@@ -17,9 +17,9 @@
 #include "tracers/ct.hpp"
 #include "util.hpp"
 
-void TracerCT::observe_instruction(instr_obs_t instr, dr_mcontext_t *mc)
+void TracerCT::observe_instruction(instr_obs_t instr, dr_mcontext_t *mc, void *dc)
 {
-    TracerABC::observe_instruction(instr, mc);
+    TracerABC::observe_instruction(instr, mc, dc);
 
     // Nothing to do if tracing is off
     if (not tracing_on) {

--- a/rvzr/model_dynamorio/backend/tracers/ind.cpp
+++ b/rvzr/model_dynamorio/backend/tracers/ind.cpp
@@ -1,0 +1,114 @@
+///
+/// File: Indirect Call Tracer implementation
+///
+// Copyright (C) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#include <optional>
+
+#include <dr_api.h> // NOLINT
+#include <dr_defines.h>
+#include <dr_ir_macros.h>
+#include <dr_ir_macros_x86.h>
+#include <dr_ir_opnd.h>
+#include <dr_ir_utils.h>
+#include <drutil.h>
+
+#include "dr_tools.h"
+#include "tracers/ind.hpp"
+
+// =================================================================================================
+// Local helper functions
+// =================================================================================================
+
+/// @brief Summary of the relevant information for indirect branches
+typedef struct {
+    pc_t src;
+    pc_t target;
+} mbr_info_t;
+
+/// @brief If the instruction is a multi-branch instruction, get the source and target,
+/// otherwise return an empty option.
+static std::optional<mbr_info_t> get_mbr_info(instr_obs_t instr, dr_mcontext_t *mc, void *dc,
+                                              instr_noalloc_t *noalloc)
+{
+    // Decode the instruction
+    instr_noalloc_init(dc, noalloc);
+    instr_t *cur_instr = instr_from_noalloc(noalloc);
+    byte *next_pc = decode(dc, (byte *)instr.pc, cur_instr);
+    DR_ASSERT_MSG(next_pc != nullptr, "[ERROR] ind_tracer: Failed to decode instruction\n");
+
+    // Check if it's an indirect jump or ret (a.k.a. multi-way branch).
+    if (not instr_is_mbr(cur_instr))
+        return {}; // ignore
+
+    const opnd_t target = instr_get_target(cur_instr);
+    app_pc target_addr = nullptr;
+    bool is_target_in_memory = false;
+
+    // Get the target, depending on the type of instruction
+    if (instr_is_return(cur_instr)) {
+        target_addr = (app_pc)mc->xsp;
+        is_target_in_memory = true;
+    } else if (opnd_is_reg(target)) {
+        const reg_id_t reg = opnd_get_reg(target);
+        target_addr = (app_pc)reg_get_value(reg, mc);
+        is_target_in_memory = false;
+    } else if (opnd_is_memory_reference(target)) {
+        target_addr = opnd_compute_address(target, mc);
+        is_target_in_memory = true;
+    } else {
+        dr_printf("[ERROR] ind_tracer: Unknown target operand type\n");
+        dr_abort();
+        return {}; // unreachable
+    }
+
+    // Load the target if it's in memory
+    if (is_target_in_memory) {
+        uint64_t loaded_val = 0;
+        if (dr_safe_read(target_addr, sizeof(uint64_t), &loaded_val, nullptr)) {
+            target_addr = (app_pc)loaded_val;
+        } else {
+            dr_printf("[ERROR] ind_tracer: Failed to read the target from memory\n");
+            dr_abort();
+            return {}; // unreachable
+        }
+    }
+
+    return mbr_info_t{.src = instr.pc, .target = (uint64_t)target_addr};
+}
+
+// =================================================================================================
+// Class implementation
+// =================================================================================================
+
+void TracerInd::observe_instruction(instr_obs_t instr, dr_mcontext_t *mc, void *dc)
+{
+    TracerABC::observe_instruction(instr, mc, dc);
+
+    // Nothing to do if tracing is off
+    if (not tracing_on) {
+        return;
+    }
+
+    // Decode the instruction
+    instr_noalloc_t noalloc;
+    const auto &mbr_info = get_mbr_info(instr, mc, dc, &noalloc);
+
+    // Skip if not a branch
+    if (not mbr_info)
+        return;
+
+    // Log source
+    trace.push_back({
+        .addr = mbr_info->src,
+        .size = 0,
+        .type = trace_entry_type_t::ENTRY_PC,
+    });
+    // Log destination
+    trace.push_back({
+        .addr = mbr_info->target,
+        .size = 0,
+        .type = trace_entry_type_t::ENTRY_IND,
+    });
+}

--- a/rvzr/model_dynamorio/backend/tracers/pc.cpp
+++ b/rvzr/model_dynamorio/backend/tracers/pc.cpp
@@ -17,9 +17,9 @@
 #include "tracers/pc.hpp"
 #include "util.hpp"
 
-void TracerPC::observe_instruction(instr_obs_t instr, dr_mcontext_t *mc)
+void TracerPC::observe_instruction(instr_obs_t instr, dr_mcontext_t *mc, void *dc)
 {
-    TracerABC::observe_instruction(instr, mc);
+    TracerABC::observe_instruction(instr, mc, dc);
 
     // Nothing to do if tracing is off
     if (not tracing_on) {

--- a/rvzr/model_dynamorio/model.py
+++ b/rvzr/model_dynamorio/model.py
@@ -302,6 +302,9 @@ class _TraceReader:
             elif type_ == TraceEntryType.ENTRY_PC:
                 val = self._layout.code_addr_to_offset(entry.addr)
                 trace.append(CTraceEntry(type_="pc", value=val))
+            elif type_ == TraceEntryType.ENTRY_IND:
+                val = self._layout.code_addr_to_offset(entry.addr)
+                trace.append(CTraceEntry(type_="ind", value=val))
 
         return CTrace(trace)
 

--- a/rvzr/model_dynamorio/trace_decoder.py
+++ b/rvzr/model_dynamorio/trace_decoder.py
@@ -31,12 +31,13 @@ class TraceEntryType(Enum):
     ENTRY_READ = 2
     ENTRY_WRITE = 3
     ENTRY_EXCEPTION = 4
+    ENTRY_IND = 5
 
 
 _TRACE_ENTRY_T: Final[str] = "struct trace_entry_t"
 _TRACE_ENTRY_DEF: Final[str] = """
 struct trace_entry_t {
-    // pc for instructions; address for memory accesses
+    // pc for instructions; address for memory accesses; target for indirect calls
     uint64_t addr;
     // instruction size for instructions; memory access size for memory accesses
     uint32_t size;

--- a/rvzr/traces.py
+++ b/rvzr/traces.py
@@ -24,7 +24,7 @@ _REG_ID_TO_NAME_ARM = {0: "x0", 1: "x1", 2: "x2", 3: "x3", 4: "x4", 5: "x5"}
 # ==================================================================================================
 # Contract Trace
 # ==================================================================================================
-CTraceEntryType = Literal["mem", "pc", "val", "reg"]
+CTraceEntryType = Literal["mem", "pc", "val", "reg", "ind"]
 
 
 class CTraceEntry(NamedTuple):
@@ -111,6 +111,8 @@ class CTrace:
                 s += "mem: " + m_col + hex(item.value) + reset_col
             elif item.type_ == "pc":
                 s += "pc: " + pc_col + hex(item.value) + reset_col
+            elif item.type_ == "ind":
+                s += "indcall: " + pc_col + hex(item.value) + reset_col
             elif item.type_ == "val":
                 s += "val: " + val_col + hex(item.value) + reset_col
             elif item.type_ == "reg":

--- a/tests/x86_tests/min_x86.json
+++ b/tests/x86_tests/min_x86.json
@@ -928,6 +928,16 @@
       {"type_": "MEM", "values": ["rsp"], "src": false, "dest": true, "width": 64}
     ]
   },
+  {"name": "call", "category": "BASE-CALL", "is_control_flow": true,
+    "operands": [
+      {"type_": "LABEL", "values": [], "src": true, "dest": false, "width": 0}
+    ],
+    "implicit_operands": [
+      {"type_": "REG", "values": ["rsp"], "src": true, "dest": true, "width": 64},
+      {"type_": "REG", "values": ["rip"], "src": true, "dest": true, "width": 64},
+      {"type_": "MEM", "values": ["rsp"], "src": false, "dest": true, "width": 64}
+    ]
+  },
   {"name": "{disp32} call", "category": "BASE-CALL", "is_control_flow": true,
     "operands": [
       {"type_": "LABEL", "values": [], "src": true, "dest": false, "width": 0}


### PR DESCRIPTION
Add a tracer that logs the target of indirect calls/indirect jumps and rets.

This requires the following modifications:
- modify `observer_instruction()` for all tracers to also receive the DR context (needed by `ind` for instruction decoding)
- add the tracer to `factory.cpp`
- add relevant changes for decoding the `ind` trace entry (in `trace_decoder.py` and `model.py`)
- add unit test and make relevant changes to the parser