### PR TITLE
model/dr: [feat] poison faulty loads

### DIFF
--- a/rvzr/model_dynamorio/backend/cli.cpp
+++ b/rvzr/model_dynamorio/backend/cli.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 
 #include <algorithm>
+#include <cstdint>
 #include <string>
 
 #include <dr_api.h> // NOLINT
@@ -79,6 +80,10 @@ const droption_t<int>    op_max_spec_window(DROPTION_SCOPE_CLIENT,
                         "max-spec-window", 250,
                         "Maximum number of speculative instructions.",
                         "Maximum number of speculative instructions.");
+const droption_t<uint64_t> op_poison_value(DROPTION_SCOPE_CLIENT,
+                        "poison-value", 0,
+                        "Value to forward on speculative faulty loads. If 0, speculative loads cause a rollback.",
+                        "Value to forward on speculative faulty loads. If 0, speculative loads cause a rollback.");
 
 // Listing Options
 const droption_t<bool> op_list_tracers(DROPTION_SCOPE_CLIENT,
@@ -124,6 +129,12 @@ void parse_cli(int argc, const char **argv, DR_PARAM_OUT cli_args_t &parsed_args
     parsed_args.max_spec_window = op_max_spec_window.get_value();
     parsed_args.list_tracers = op_list_tracers.get_value();
     parsed_args.list_speculators = op_list_speculators.get_value();
+    uint64_t poison_value = op_poison_value.get_value();
+    if (poison_value == 0) {
+        parsed_args.poison_value = {};
+    } else {
+        parsed_args.poison_value = poison_value;
+    }
 
     // Check values
     if (not validate_tracer(&parsed_args)) {

--- a/rvzr/model_dynamorio/backend/include/cli.hpp
+++ b/rvzr/model_dynamorio/backend/include/cli.hpp
@@ -6,8 +6,11 @@
 
 #pragma once
 
-#include <dr_defines.h> // DR_PARAM_OUT
+#include <cstdint>
+#include <optional>
 #include <string>
+
+#include <dr_defines.h> // DR_PARAM_OUT
 
 struct cli_args_t {
     std::string tracer_type;
@@ -22,6 +25,7 @@ struct cli_args_t {
     int max_spec_window;
     bool list_tracers;
     bool list_speculators;
+    std::optional<uint64_t> poison_value;
 };
 
 /// @brief Parse the command line arguments

--- a/rvzr/model_dynamorio/backend/include/factory.hpp
+++ b/rvzr/model_dynamorio/backend/include/factory.hpp
@@ -33,11 +33,13 @@ std::vector<std::string> get_tracer_list();
 /// @param max_nesting_ The maximum nesting level for the speculator
 /// @param max_spec_window_ The maximum size of the speculation window
 /// @param logger Where to log events for debugging
+/// @param poison_value If not empty, this value will be forwarded on speculative faulty loads
 /// @return A unique pointer to the created speculator instance
 /// @throw std::invalid_argument if the speculator name is unknown
 std::unique_ptr<SpeculatorABC> create_speculator(const std::string &speculator_type,
                                                  int max_nesting_, int max_spec_window_,
-                                                 Logger &logger);
+                                                 Logger &logger,
+                                                 std::optional<uint64_t> poison_value);
 
 /// @brief Get a list of all available speculators
 /// @return A list of all available speculators

--- a/rvzr/model_dynamorio/model.py
+++ b/rvzr/model_dynamorio/model.py
@@ -90,7 +90,7 @@ class DynamoRIOModel(Model):
         test_case.get_obj().save_rcbf(self._rcbf_file)
 
     def _trace_test_case_with_addr(self, inputs: List[InputData],
-                                  unused_nesting: int) -> Tuple[List[CTrace], int, int]:
+                                   unused_nesting: int) -> Tuple[List[CTrace], int, int]:
         """
         Execute the test case with the given inputs on DR backend and return the traces
         and the sandbox addresses.

--- a/rvzr/model_dynamorio/model.py
+++ b/rvzr/model_dynamorio/model.py
@@ -89,7 +89,7 @@ class DynamoRIOModel(Model):
         # store the test case in the RCBF format
         test_case.get_obj().save_rcbf(self._rcbf_file)
 
-    def trace_test_case_with_addr(self, inputs: List[InputData],
+    def _trace_test_case_with_addr(self, inputs: List[InputData],
                                   unused_nesting: int) -> Tuple[List[CTrace], int, int]:
         """
         Execute the test case with the given inputs on DR backend and return the traces
@@ -143,7 +143,7 @@ class DynamoRIOModel(Model):
         :return: list of contract traces, one per input
         """
         # Just ignore sandbox addresses
-        trace, _, _ = self.trace_test_case_with_addr(inputs, nesting)
+        trace, _, _ = self._trace_test_case_with_addr(inputs, nesting)
         return trace
 
     def trace_test_case_with_taints(self, inputs: List[InputData],

--- a/rvzr/model_dynamorio/model.py
+++ b/rvzr/model_dynamorio/model.py
@@ -44,6 +44,7 @@ class DynamoRIOModel(Model):
 
     _trace_file: str = ""
     _dbg_trace_file: str = ""
+    poison_value: int = 0  # If this value is != 0, it will be returned on speculative faulty loads
 
     # ----------------------------------------------------------------------------------------------
     # Constructor/Destructor
@@ -55,6 +56,7 @@ class DynamoRIOModel(Model):
         #       for customization of the memory layout
         self._enable_mismatch_check_mode = enable_mismatch_check_mode
         self.is_speculative = True  # may be changed by configure_clauses
+        self.poison_value = 0  # may be changed later
 
         with tempfile.NamedTemporaryFile("wb", delete=False) as trace_f:
             self._trace_file = trace_f.name
@@ -87,16 +89,18 @@ class DynamoRIOModel(Model):
         # store the test case in the RCBF format
         test_case.get_obj().save_rcbf(self._rcbf_file)
 
-    def trace_test_case(self, inputs: List[InputData], nesting: int) -> List[CTrace]:
+    def trace_test_case_with_addr(self, inputs: List[InputData],
+                                  unused_nesting: int) -> Tuple[List[CTrace], int, int]:
         """
         Execute the test case with the given inputs on DR backend and return the traces
+        and the sandbox addresses.
         :param inputs: input sequence to trace
         :param nesting: maximum nesting level to emulated in the model
-        :return: list of contract traces, one per input
+        :return: list of contract traces, one per input, and the addresses of the sandbox
         """
         assert self._test_case is not None, "No test case was loaded"
         if len(inputs) == 0:
-            return []
+            return [], 0, 0
 
         # remove the previous RDBF file if it exists and create a new one
         if self._rdbf_file is not None and os.path.exists(self._rdbf_file):
@@ -127,9 +131,20 @@ class DynamoRIOModel(Model):
         if self._enable_mismatch_check_mode:
             # In this mode, the contract trace is the register values at the end of the test case
             arch_traces = [CTrace(t.get_typed()[-6:]) for t in dbg_traces]
-            return arch_traces
+            return arch_traces, code_base_addr, data_base_addr
 
-        return traces
+        return traces, code_base_addr, data_base_addr
+
+    def trace_test_case(self, inputs: List[InputData], nesting: int) -> List[CTrace]:
+        """
+        Execute the test case with the given inputs on DR backend and return the traces
+        :param inputs: input sequence to trace
+        :param nesting: maximum nesting level to emulated in the model
+        :return: list of contract traces, one per input
+        """
+        # Just ignore sandbox addresses
+        trace, _, _ = self.trace_test_case_with_addr(inputs, nesting)
+        return trace
 
     def trace_test_case_with_taints(self, inputs: List[InputData],
                                     nesting: int) -> Tuple[List[CTrace], List[InputTaint]]:
@@ -233,6 +248,9 @@ class DynamoRIOModel(Model):
             f" --trace-output {self._trace_file}"
         if self._enable_mismatch_check_mode:
             flags += f" --log-level 1 --debug-trace-output {self._dbg_trace_file}"
+        if self.poison_value != 0:
+            flags += f" --poison-value {self.poison_value}"
+
         binary = _ADAPTER_PATH
         args = f"{self._rcbf_file} {self._rdbf_file}"
         cmd = _DRRUN_CMD.format(flags=flags, binary=binary, args=args)


### PR DESCRIPTION
Add the `--poison-value` flag to the DR client. If a value is specified though this flag, such value will be forwarded to the destination register of faulty loads during speculation, instead of just rolling back the speculation.

This is useful in cases where the faulty load's address is attacker-controlled to evaluate the presence of leak gadgets (e.g. double loads or dispatch gadgets.