### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-lint-and-test.yaml
+++ b/.github/workflows/python-lint-and-test.yaml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python Lint and Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/sca-fuzzer/security/code-scanning/1](https://github.com/microsoft/sca-fuzzer/security/code-scanning/1)

To fix the problem, explicitly add a `permissions:` block that grants the least privilege necessary to the workflow. The best practice in this scenario is to add it at the workflow (top) level, so it covers all jobs, unless specific jobs need elevated access. Since this workflow only installs dependencies, runs linters, and executes tests (with no write-back or repo modification), only `contents: read` is required. The `permissions:` key should be added just below the `name:` field and before the `on:` field for clarity and proper precedence.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
